### PR TITLE
Don't wrap dropdown content.

### DIFF
--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -145,9 +145,7 @@ respectively.
           <iron-icon icon="arrow-drop-down" suffix></iron-icon>
         </paper-input>
       </div>
-      <div class="dropdown-content">
-        <content select=".dropdown-content"></content>
-      </div>
+      <content select=".dropdown-content"></content>
     </paper-menu-button>
   </template>
 </dom-module>


### PR DESCRIPTION
This prevents the focusable element from getting buried in extra layers
of DOM, making it difficult to decide what should or should not be
focused.

Related to https://github.com/PolymerElements/paper-menu-button/pull/19
Related to https://github.com/PolymerElements/iron-dropdown/pull/22

Combined, these PRs close https://github.com/PolymerElements/paper-dropdown-menu/issues/9