### PR TITLE
Dropdown values can be deselected.

### DIFF
--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -43,6 +43,9 @@ Example:
 
 This example renders a dropdown menu with 4 options.
 
+Similarly to using `iron-select`, `iron-deselect` events will cause the
+current selection of the `paper-dropdown-menu` to be cleared.
+
 ### Styling
 
 The following custom properties and mixins are also available for styling:
@@ -73,6 +76,12 @@ respectively.
       position: relative;
       text-align: left;
       cursor: pointer;
+
+      /* NOTE(cdata): Both values are needed, since some phones require the
+       * value to be `transparent`.
+       */
+      -webkit-tap-highlight-color: rgba(0,0,0,0);
+      -webkit-tap-highlight-color: transparent;
 
       --paper-input-container-input: {
         overflow: hidden;
@@ -131,6 +140,7 @@ respectively.
       disabled="[[disabled]]"
       no-animations="[[noAnimations]]"
       on-iron-select="_onIronSelect"
+      on-iron-deselect="_onIronDeselect"
       opened="{{opened}}">
       <div class="dropdown-trigger">
         <paper-ripple></paper-ripple>
@@ -301,6 +311,15 @@ respectively.
        */
       _onIronSelect: function(event) {
         this._setSelectedItem(event.detail.item);
+      },
+
+      /**
+       * A handler that is called when `iron-deselect` is fired.
+       *
+       * @param {CustomEvent} event An `iron-deselect` event.
+       */
+      _onIronDeselect: function(event) {
+        this._setSelectedItem(null);
       },
 
       /**

--- a/test/paper-dropdown-menu.html
+++ b/test/paper-dropdown-menu.html
@@ -119,6 +119,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(dropdownMenu.selectedItem).to.be.equal(secondItem);
         });
       });
+
+      suite('deselecting', function() {
+        var menu;
+
+        setup(function() {
+          dropdownMenu = fixture('PreselectedDropdownMenu');
+          menu = Polymer.dom(dropdownMenu).querySelector('.dropdown-content');
+        });
+
+        test('an `iron-deselect` event clears the current selection', function() {
+          menu.selected = null;
+          expect(dropdownMenu.selectedItem).to.be.equal(null);
+        });
+      });
     });
   </script>
 


### PR DESCRIPTION
This is enabled by listening for a bubbling `iron-deselect` event and
setting the current selection to `null` when it is received.

Fixes #39 