### PR TITLE
fix dropdown on ie

### DIFF
--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -117,6 +117,7 @@ respectively.
     }
 
     paper-menu-button {
+      display: block;
       @apply(--paper-dropdown-menu-button);
     }
 
@@ -199,7 +200,7 @@ respectively.
          * The last selected item. An item is selected if the dropdown menu has
          * a child with class `dropdown-content`, and that child triggers an
          * `iron-select` event with the selected `item` in the `detail`.
-         * 
+         *
          * @type {?Object}
          */
         selectedItem: {
@@ -366,4 +367,3 @@ respectively.
     });
   })();
 </script>
-


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-dropdown-menu/issues/31

Before:
<img width="286" alt="screen shot 2015-09-30 at 2 06 25 pm" src="https://cloud.githubusercontent.com/assets/1369170/10206570/789ea794-677c-11e5-9f60-028cacc2b212.png">

After:
<img width="271" alt="screen shot 2015-09-30 at 2 06 09 pm" src="https://cloud.githubusercontent.com/assets/1369170/10206575/7a609b28-677c-11e5-8b80-a54136b45ace.png">
