### PR TITLE
fix dropdown padding

### DIFF
--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -110,16 +110,17 @@ respectively.
     }
 
     paper-ripple {
-      top: 20px;
-      left: 8px;
-      bottom: 16px;
-      right: 8px;
+      top: 12px;
+      left: 0px;
+      bottom: 8px;
+      right: 0px;
 
       @apply(--paper-dropdown-menu-ripple);
     }
 
     paper-menu-button {
       display: block;
+      padding: 0;
       @apply(--paper-dropdown-menu-button);
     }
 
@@ -364,7 +365,7 @@ respectively.
         // derived from the metrics of elements internal to `paper-input`'s
         // template. The metrics will change depending on whether or not the
         // input has a floating label.
-        return noLabelFloat ? -4 : 16;
+        return noLabelFloat ? -4 : 8;
       }
     });
   })();


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-dropdown-menu/issues/7#issuecomment-145831835. The contained `paper-menu-button` was getting a `padding: 8px`, so this PR mostly undoes it from everywhere.

This is the straight-up the element demo, with a plain `paper-input` of a fixed width. The only change is that I removed the `text-align: center` on the `horizontal-section` to make sure the text lines up too.

Before:
<img width="270" alt="screen shot 2015-10-06 at 12 43 22 pm" src="https://cloud.githubusercontent.com/assets/1369170/10320377/0cef7c5c-6c28-11e5-92e8-91e834eb0e78.png">
And the ripple, just to make sure I didn't break that:
<img width="262" alt="screen shot 2015-10-06 at 12 43 33 pm" src="https://cloud.githubusercontent.com/assets/1369170/10320391/23983e3a-6c28-11e5-95dd-a9ea1af1297b.png">


After:
<img width="273" alt="screen shot 2015-10-06 at 12 42 43 pm" src="https://cloud.githubusercontent.com/assets/1369170/10320401/2ae44cce-6c28-11e5-9c66-2f01e95b88e6.png">
And the ripple:
<img width="270" alt="screen shot 2015-10-06 at 12 42 47 pm" src="https://cloud.githubusercontent.com/assets/1369170/10320411/344d7b3c-6c28-11e5-9e1d-7d1efa6db876.png">


