### PR TITLE
add form behaviour

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,9 @@
     "paper-input": "polymerelements/paper-input#^1.0.9",
     "paper-menu-button": "polymerelements/paper-menu-button#^1.0.0",
     "paper-ripple": "polymerelements/paper-ripple#^1.0.0",
-    "paper-styles": "polymerelements/paper-styles#^1.0.0"
+    "paper-styles": "polymerelements/paper-styles#^1.0.0",
+    "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.0",
+    "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^1.0.0"
   },
   "devDependencies": {
     "iron-component-page": "polymerelements/iron-component-page#^1.0.0",

--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -19,6 +19,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../iron-selector/iron-selectable.html">
+<link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
+<link rel="import" href="../iron-validatable-behavior/iron-validatable-behavior.html">
 
 <!--
 Material design: [Dropdown menus](https://www.google.com/design/spec/components/buttons.html#buttons-dropdown-buttons)
@@ -149,6 +151,7 @@ respectively.
       <div class="dropdown-trigger">
         <paper-ripple></paper-ripple>
         <paper-input
+          invalid="[[invalid]]"
           readonly
           disabled="[[disabled]]"
           value="[[selectedItemLabel]]"
@@ -184,7 +187,9 @@ respectively.
 
       behaviors: [
         Polymer.IronControlState,
-        Polymer.IronButtonState
+        Polymer.IronButtonState,
+        Polymer.IronFormElementBehavior,
+        Polymer.IronValidatableBehavior
       ],
 
       properties: {
@@ -210,6 +215,17 @@ respectively.
           type: Object,
           notify: true,
           readOnly: true
+        },
+
+        /**
+         * The value for this element that will be used when submitting in
+         * a form. It is read only, and will always have the same value
+         * as `selectedItemLabel`.
+         */
+        value: {
+          type: String,
+          notify: true,
+          computed: '_computeValue(selectedItemLabel)'
         },
 
         /**
@@ -354,6 +370,15 @@ respectively.
       },
 
       /**
+       * Update `value` based on the value of `selectedItemLabel`.
+       *
+       * @param {String} selectedItemLabel The label of the selected item
+       */
+      _computeValue: function(selectedItemLabel) {
+        return selectedItemLabel;
+      },
+
+      /**
        * Compute the vertical offset of the menu based on the value of
        * `noLabelFloat`.
        *
@@ -366,7 +391,17 @@ respectively.
         // template. The metrics will change depending on whether or not the
         // input has a floating label.
         return noLabelFloat ? -4 : 8;
-      }
+      },
+
+      /**
+       * Returns false if the element is required and does not have a selection,
+       * and true otherwise.
+       * @return {Boolean} true if `required` is false, or if `required` is true
+       * and the element has a valid selection.
+       */
+      _getValidity: function() {
+        return this.disabled || !this.required || (this.required && this.value);
+      },
     });
   })();
 </script>

--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -201,7 +201,7 @@ respectively.
         selectedItemLabel: {
           type: String,
           notify: true,
-          computed: '_computeSelectedItemLabel(selectedItem)'
+          readOnly: true
         },
 
         /**
@@ -225,7 +225,7 @@ respectively.
         value: {
           type: String,
           notify: true,
-          computed: '_computeValue(selectedItemLabel)'
+          readOnly: true
         },
 
         /**
@@ -294,6 +294,10 @@ respectively.
         'aria-haspopup': 'true'
       },
 
+      observers: [
+        '_selectedItemChanged(selectedItem)'
+      ],
+
       attached: function() {
         // NOTE(cdata): Due to timing, a preselected value in a `IronSelectable`
         // child will cause an `iron-select` event to fire while the element is
@@ -361,21 +365,16 @@ respectively.
        * @param {Element} selectedItem A selected Element item, with an
        * optional `label` property.
        */
-      _computeSelectedItemLabel: function(selectedItem) {
+      _selectedItemChanged: function(selectedItem) {
+        var value = '';
         if (!selectedItem) {
-          return '';
+          value = '';
+        } else {
+          value = selectedItem.label || selectedItem.textContent.trim();
         }
 
-        return selectedItem.label || selectedItem.textContent.trim();
-      },
-
-      /**
-       * Update `value` based on the value of `selectedItemLabel`.
-       *
-       * @param {String} selectedItemLabel The label of the selected item
-       */
-      _computeValue: function(selectedItemLabel) {
-        return selectedItemLabel;
+        this._setValue(value);
+        this._setSelectedItemLabel(value);
       },
 
       /**
@@ -401,7 +400,7 @@ respectively.
        */
       _getValidity: function() {
         return this.disabled || !this.required || (this.required && this.value);
-      },
+      }
     });
   })();
 </script>

--- a/test/paper-dropdown-menu.html
+++ b/test/paper-dropdown-menu.html
@@ -133,6 +133,43 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(dropdownMenu.selectedItem).to.be.equal(null);
         });
       });
+
+      suite('validation', function() {
+        test('a non required dropdown is valid regardless of its selection', function() {
+          var dropdownMenu = fixture('TrivialDropdownMenu');
+          menu = Polymer.dom(dropdownMenu).querySelector('.dropdown-content');
+
+          // no selection.
+          expect(dropdownMenu.validate()).to.be.true;
+          expect(dropdownMenu.invalid).to.be.false;
+          expect(dropdownMenu.value).to.not.be.ok;
+
+          // some selection.
+          menu.selected = 1;
+          expect(dropdownMenu.validate()).to.be.true;
+          expect(dropdownMenu.invalid).to.be.false;
+          expect(dropdownMenu.value).to.be.equal('Bar');
+        });
+
+        test('a required dropdown is invalid without a selection', function() {
+          var dropdownMenu = fixture('TrivialDropdownMenu');
+          dropdownMenu.required = true;
+
+          // no selection.
+          expect(dropdownMenu.validate()).to.be.false;
+          expect(dropdownMenu.invalid).to.be.true;
+          expect(dropdownMenu.value).to.not.be.ok;
+        });
+
+        test('a required dropdown is valid with a selection', function() {
+          var dropdownMenu = fixture('PreselectedDropdownMenu');
+          dropdownMenu.required = true;
+          
+          expect(dropdownMenu.validate()).to.be.true;
+          expect(dropdownMenu.invalid).to.be.false;
+          expect(dropdownMenu.value).to.be.equal('Bar');
+        });
+      });
     });
   </script>
 


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-dropdown-menu/issues/32, https://github.com/PolymerElements/paper-dropdown-menu/issues/54

- adds the `IronFormElementBehaviour` so that it can be tracked in an `iron-form`
- adds the `IronValidatableBehaviour` so that no-selection, required dropdowns are invalid
- continues to not be able to spell `behaviour` the american way outside of code