### PR TITLE
_getValidity is supposed to take an argument

### DIFF
--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -395,11 +395,13 @@ respectively.
       /**
        * Returns false if the element is required and does not have a selection,
        * and true otherwise.
+       * 
+       * @param {*} value The value to validate.
        * @return {boolean} true if `required` is false, or if `required` is true
        * and the element has a valid selection.
        */
-      _getValidity: function() {
-        return this.disabled || !this.required || (this.required && this.value);
+      _getValidity: function(value) {
+        return this.disabled || !this.required || (this.required && !!value);
       }
     });
   })();


### PR DESCRIPTION
The compiler pointed out that `IronValidatableBehavior` wants `_getValidity` to be told what value to validate, rather than to introspect for itself.

Also, use `!!` to coerce to boolean.