### PR TITLE
Add allow-outside-scroll property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "iron-iconset-svg": "polymerelements/iron-iconset-svg#^1.0.0",
     "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^1.0.0",
     "paper-input": "PolymerElements/paper-input#^1.0.9",
-    "paper-menu-button": "PolymerElements/paper-menu-button#^1.0.0",
+    "paper-menu-button": "PolymerElements/paper-menu-button#^1.2.0",
     "paper-ripple": "PolymerElements/paper-ripple#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0"
   },

--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -156,7 +156,8 @@ respectively.
       no-animations="[[noAnimations]]"
       on-iron-select="_onIronSelect"
       on-iron-deselect="_onIronDeselect"
-      opened="{{opened}}">
+      opened="{{opened}}"
+      allow-outside-scroll="[[allowOutsideScroll]]">
       <div class="dropdown-trigger">
         <paper-ripple></paper-ripple>
         <!-- paper-input has type="text" for a11y, do not remove -->
@@ -257,6 +258,17 @@ respectively.
             notify: true,
             value: false,
             observer: '_openedChanged'
+          },
+
+          /**
+           * By default, the dropdown will constrain scrolling on the page
+           * to itself when opened.
+           * Set to true in order to prevent scroll from being constrained
+           * to the dropdown when it opens.
+           */
+          allowOutsideScroll: {
+            type: Boolean,
+            value: false
           },
 
           /**


### PR DESCRIPTION
Adding an allow-scroll-lock property implemented in `iron-dropdown` [PR #25](https://github.com/PolymerElements/iron-dropdown/pull/25), to make it accessible in `paper-dropdown-menu`. This depends on 'paper-menu-button' [PR #35](https://github.com/PolymerElements/paper-menu-button/pull/35) being merged.