### PR TITLE
Support `horizontalAlign` on `paper-menu-button`

### DIFF
--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -141,7 +141,7 @@ respectively.
     <paper-menu-button
       id="menuButton"
       vertical-align="top"
-      horizontal-align="right"
+      horizontal-align="[[horizontalAlign]]"
       vertical-offset="[[_computeMenuVerticalOffset(noLabelFloat)]]"
       disabled="[[disabled]]"
       no-animations="[[noAnimations]]"
@@ -240,6 +240,16 @@ respectively.
          */
         placeholder: {
           type: String
+        },
+
+        /**
+         * The orientation against which to align the menu dropdown
+         * horizontally relative to the dropdown trigger.
+         */
+        horizontalAlign: {
+          type: String,
+          value: 'right',
+          reflectToAttribute: true
         },
 
         /**


### PR DESCRIPTION
On wide `paper-dropdown-menu`'s (with a set `width`) having the dropdown dropping from the right side looks *terrible*, so added support for the `horizontal-align` attribute.