### PR TITLE
prettify demo

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
+    "iron-demo-helpers": "polymerelements/iron-demo-helpers#^1.0.0",
     "test-fixture": "polymerelements/test-fixture#^1.0.0",
     "iron-test-helpers": "polymerelements/iron-test-helpers#^1.0.0",
     "paper-item": "polymerelements/paper-item#^1.0.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,6 +19,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
+  <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+  <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
   <link rel="import" href="../../paper-button/paper-button.html">
   <link rel="import" href="../../paper-item/paper-item.html">
   <link rel="import" href="../../paper-listbox/paper-listbox.html">
@@ -26,152 +28,161 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../paper-tabs/paper-tabs.html">
   <link rel="import" href="../paper-dropdown-menu.html">
 
-  <style is="custom-style">
-    paper-dropdown-menu {
-      text-align: left;
-      margin: auto;
-      width: 180px;
-    }
-
-    paper-dropdown-menu.letters {
-      width: 90px;
-    }
-
+  <style is="custom-style" include="demo-pages-shared-styles">
     paper-tabs {
       width: 400px;
     }
 
-    .horizontal-section {
-      text-align: center;
+    .vertical-section-container {
+      max-width: 500px;
     }
 
-    .nounderline {
-      --paper-input-container-underline: {
-        display: none;
-      };
+    paper-dropdown-menu {
+      width: 200px;
     }
   </style>
 
 </head>
-<body>
+<body unresolved>
+  <div class="vertical-section-container centered">
+    <h4>This is a plain paper-dropdown-menu</h4>
+    <demo-snippet class="centered-demo">
+      <template>
+        <paper-dropdown-menu label="Dinosaurs">
+          <paper-listbox class="dropdown-content">
+            <paper-item>allosaurus</paper-item>
+            <paper-item>brontosaurus</paper-item>
+            <paper-item>carcharodontosaurus</paper-item>
+            <paper-item>diplodocus</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu>
+      </template>
+    </demo-snippet>
 
-  <template id="Demo" is="dom-bind">
+    <h4>You can pre-select a value using the <i>selected</i> attribute</h4>
+    <demo-snippet class="centered-demo">
+      <template>
+        <paper-dropdown-menu label="Dinosaurs">
+          <paper-listbox class="dropdown-content" selected="1">
+            <paper-item>allosaurus</paper-item>
+            <paper-item>brontosaurus</paper-item>
+            <paper-item>carcharodontosaurus</paper-item>
+            <paper-item>diplodocus</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu>
+      </template>
+    </demo-snippet>
 
-    <div class="horizontal-section-container">
-      <div>
-        <h4>Basic Menu</h4>
-        <div class="horizontal-section">
+    <h4>You can change the direction in which the menu opens</h4>
+    <demo-snippet class="centered-demo">
+      <template>
+        <paper-dropdown-menu label="Upwards and to the left!" vertical-align="bottom" horizontal-align="left">
+          <paper-listbox class="dropdown-content">
+            <paper-item>allosaurus</paper-item>
+            <paper-item>brontosaurus</paper-item>
+            <paper-item>carcharodontosaurus</paper-item>
+            <paper-item>diplodocus</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu>
+      </template>
+    </demo-snippet>
+
+
+    <h4>A paper-dropdown-menu can be disabled</h4>
+    <demo-snippet class="centered-demo">
+      <template>
+        <paper-dropdown-menu label="Disabled dinosaurs" disabled>
+          <paper-listbox class="dropdown-content">
+            <paper-item>allosaurus</paper-item>
+            <paper-item>brontosaurus</paper-item>
+            <paper-item>carcharodontosaurus</paper-item>
+            <paper-item>diplodocus</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu>
+      </template>
+    </demo-snippet>
+
+    <!-- TODO(noms): enable this demo when the webcomponentsjs bug is fixed -->
+    <!-- <h4>Here is an example of a long, scrolling menu, using a <i>dom-repeat</i></h4>
+    <demo-snippet class="centered-demo">
+      <template>
+        <template is="dom-bind" id="Demo">
           <paper-dropdown-menu label="Dinosaurs">
             <paper-listbox class="dropdown-content">
-              <template is="dom-repeat" items="[[dinosaurs]]" as="dinosaur">
+              <template is="dom-repeat" items='[[dinosaurs]]' as="dinosaur">
                 <paper-item>[[dinosaur]]</paper-item>
               </template>
             </paper-listbox>
           </paper-dropdown-menu>
-        </div>
-      </div>
-    </div>
+        </template>
+      </template>
+    </demo-snippet> -->
 
-    <div class="horizontal-section-container">
-      <div>
-        <h4>Pre-selected Value</h4>
-        <div class="horizontal-section">
-          <paper-dropdown-menu label="Dinosaurs">
-            <paper-listbox class="dropdown-content" selected="1">
-              <template is="dom-repeat" items="[[dinosaurs]]" as="dinosaur">
-                <paper-item>[[dinosaur]]</paper-item>
-              </template>
-            </paper-listbox>
-          </paper-dropdown-menu>
-        </div>
-      </div>
-    </div>
+    <h4>A paper-dropdown-menu can contain any kind of content, such as tabs</h4>
+    <demo-snippet class="centered-demo">
+      <template>
+        <paper-dropdown-menu label="Menu tabs!?">
+          <paper-tabs class="dropdown-content">
+            <paper-tab>cheddar</paper-tab>
+            <paper-tab>stilton</paper-tab>
+            <paper-tab>emmental</paper-tab>
+          </paper-tabs>
+        </paper-dropdown-menu>
+      </template>
+    </demo-snippet>
 
-    <div class="horizontal-section-container">
-      <div>
-        <h4>Disabled</h4>
-        <div class="horizontal-section">
-          <paper-dropdown-menu disabled label="Disabled">
-            <paper-listbox class="dropdown-content">
-              <template is="dom-repeat" items="[[letters]]" as="letter">
-                <paper-item>[[letter]]</paper-item>
-              </template>
-            </paper-listbox>
-          </paper-dropdown-menu>
-        </div>
-      </div>
-    </div>
+    <h4>You can remove the ripple and the animations</h4>
+    <demo-snippet class="centered-demo">
+      <template>
+        <paper-dropdown-menu label="Dinosaurs" noink no-animations>
+          <paper-listbox class="dropdown-content">
+            <paper-item>allosaurus</paper-item>
+            <paper-item>brontosaurus</paper-item>
+            <paper-item>carcharodontosaurus</paper-item>
+            <paper-item>diplodocus</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu>
+      </template>
+    </demo-snippet>
 
-    <div class="horizontal-section-container">
-      <div>
-        <h4>Alternative Content</h4>
-        <div class="horizontal-section">
-          <paper-dropdown-menu label="Menu tabs!?">
-            <paper-tabs class="dropdown-content">
-              <template is="dom-repeat" items="[[letters]]" as="letter">
-                <paper-tab>[[letter]]</paper-tab>
-              </template>
-            </paper-tabs>
-          </paper-dropdown-menu>
-        </div>
-      </div>
-    </div>
-
-    <div class="horizontal-section-container">
-      <div>
-        <h4>No underline (menu from bottom)</h4>
-        <div class="horizontal-section">
-          <paper-dropdown-menu class="nounderline" label="Letters" vertical-align="bottom">
-            <paper-listbox class="dropdown-content">
-              <template is="dom-repeat" items="[[letters]]" as="letter">
-                <paper-item>[[letter]]</paper-item>
-              </template>
-            </paper-listbox>
-          </paper-dropdown-menu>
-        </div>
-      </div>
-    </div>
-
-    <div class="horizontal-section-container">
-      <div>
-        <h4>No Label Float</h4>
-        <div class="horizontal-section">
-          <paper-dropdown-menu class="letters" label="Letters" no-label-float>
-            <paper-listbox class="dropdown-content">
-              <template is="dom-repeat" items="[[letters]]" as="letter">
-                <paper-item>[[letter]]</paper-item>
-              </template>
-            </paper-listbox>
-          </paper-dropdown-menu>
-        </div>
-      </div>
-    </div>
-
-    <div class="horizontal-section-container">
-      <div>
-        <h4>No Ripple, No Animations</h4>
-        <div class="horizontal-section">
-          <paper-dropdown-menu label="Dinosaurs" noink no-animations>
-            <paper-listbox class="dropdown-content">
-              <template is="dom-repeat" items="[[dinosaurs]]" as="dinosaur">
-                <paper-item>[[dinosaur]]</paper-item>
-              </template>
-            </paper-listbox>
-          </paper-dropdown-menu>
-        </div>
-      </div>
-    </div>
-
-  </template>
+    <h4>You can style a paper-dropdown-menu using custom properties</h4>
+    <demo-snippet class="centered-demo">
+      <template>
+        <style is="custom-style">
+          paper-dropdown-menu.custom {
+            --paper-input-container-label: {
+              color: white;
+              background-color: var(--paper-pink-500);
+              font-style: italic;
+              text-align: center;
+              font-weight: bold;
+            };
+            --paper-input-container-input: {
+              color: var(--paper-indigo-500);
+              font-style: normal;
+              font-family: serif;
+              text-transform: uppercase;
+            }
+            /* no underline */
+            --paper-input-container-underline: {
+              display: none;
+            };
+          }
+        </style>
+        <paper-dropdown-menu class="custom" label="Custom" no-label-float>
+          <paper-listbox class="dropdown-content">
+            <paper-item>allosaurus</paper-item>
+            <paper-item>brontosaurus</paper-item>
+            <paper-item>carcharodontosaurus</paper-item>
+            <paper-item>diplodocus</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu>
+      </template>
+    </demo-snippet>
+  </div>
 
   <script>
-    Demo.letters = [
-      'alpha',
-      'beta',
-      'gamma',
-      'delta',
-      'epsilon'
-    ];
+  document.addEventListener('WebComponentsReady', function() {
     Demo.dinosaurs = [
       'allosaurus',
       'brontosaurus',
@@ -200,7 +211,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'yandusaurus',
       'zephyrosaurus'
     ];
+  });
   </script>
-
 </body>
 </html>


### PR DESCRIPTION
(This is a super old branch I had opened before the holidays)
Added `demo-snippet`. Had to temporarily comment out the `dom-bind` demo, since it's busted on IE (because of nested templates in `webcomponents.js`), but I'll add it back as soon as that's fixed.

Looks like this (and more):
<img width="573" alt="screen shot 2016-01-14 at 12 31 06 pm" src="https://cloud.githubusercontent.com/assets/1369170/12336727/dc75b2d0-baba-11e5-8ef0-0fee04474903.png">
