### PR TITLE
Menu value set with item value

### DIFF
--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -384,21 +384,21 @@ respectively.
         },
 
         /**
-         * Compute the label for the dropdown given a selected item.
+         * Compute label and value for the dropdown given a selected item.
          *
          * @param {Element} selectedItem A selected Element item, with an
          * optional `label` property.
          */
         _selectedItemChanged: function(selectedItem) {
           var value = '';
-          if (!selectedItem) {
-            value = '';
-          } else {
-            value = selectedItem.label || selectedItem.textContent.trim();
+          var label = '';
+          if (selectedItem) {
+            label = selectedItem.label || selectedItem.textContent.trim();
+            value = selectedItem.value || label;
           }
 
           this._setValue(value);
-          this._setSelectedItemLabel(value);
+          this._setSelectedItemLabel(label);
         },
 
         /**

--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -394,7 +394,7 @@ respectively.
           var label = '';
           if (selectedItem) {
             label = selectedItem.label || selectedItem.textContent.trim();
-            value = selectedItem.value || label;
+            value = selectedItem.value || selectedItem.getAttribute("value") || label;
           }
 
           this._setValue(value);


### PR DESCRIPTION
In case items  have 'value' attributes they are used to set the menu
'value'.
Doing so also the dropdown menus differenziate between menu label and
menu value.

With this fix 'Cars' fields in the iron-form demo for both 'GET' 'and 'POST' cases can generate the same submit parameter (After having associated the right 'value' attributes to the paper-items).