### PR TITLE
Fix #127. Clarify API doc about menu child, events.

### DIFF
--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -30,10 +30,6 @@ Material design: [Dropdown menus](https://www.google.com/design/spec/components/
 item is displayed in the control. If no item is selected, the `label` is
 displayed instead.
 
-The child element with the class `dropdown-content` will be used as the dropdown
-menu. It could be a `paper-listbox` or element that triggers `iron-select` when
-selecting its children.
-
 Example:
 
     <paper-dropdown-menu label="Your favourite pastry">
@@ -47,8 +43,18 @@ Example:
 
 This example renders a dropdown menu with 4 options.
 
-Similarly to using `iron-select`, `iron-deselect` events will cause the
-current selection of the `paper-dropdown-menu` to be cleared.
+The child element with the class `dropdown-content` is used as the dropdown
+menu. This can be a [`paper-listbox`](paper-listbox), or any other or
+element that acts like an [`iron-selector`](iron-selector).
+
+Specifically, the menu child must fire an
+[`iron-select`](iron-selector#event-iron-select) event when one of its
+children is selected, and an [`iron-deselect`](iron-selector#event-iron-deselect)
+event when a child is deselected. The selected or deselected item must
+be passed as the event's `detail.item` property.
+
+Applications can listen for the `iron-select` and `iron-deselect` events
+to react when options are selected and deselected.
 
 ### Styling
 


### PR DESCRIPTION
This was spurred by a conversation on polymer-dev. I think this is a little clearer, because we expect people to provide a child element that fires `iron-select`, but listening for that `iron-select` is probably one of the key ways to get the output of the element. 

Although you can also bind to `value`, `selectedItem`, or `selectedItemLabel`, which I didn't mention. Hm... Well, anyway, it's a start.

Perhaps the example should show one of these things (for example, binding to `value` or `selectedItemLabel`) as well to make it more of a complete example?