### PR TITLE
accio paper-dropdown-light! ⚡️

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
     "iron-iconset-svg": "polymerelements/iron-iconset-svg#^1.0.0",
     "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^1.0.0",
+    "paper-behaviors": "PolymerElements/paper-behaviors#^1.0.0",
     "paper-input": "PolymerElements/paper-input#^1.0.9",
     "paper-menu-button": "PolymerElements/paper-menu-button#^1.0.0",
     "paper-ripple": "PolymerElements/paper-ripple#^1.0.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -103,7 +103,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </paper-listbox>
         </paper-dropdown-menu>
 
-        <paper-dropdown-menu-light label="Upwards and to the left!" vertical-align="bottom" horizontal-align="left">
+        <paper-dropdown-menu-light label="Upwards and to the left! (light)" vertical-align="bottom" horizontal-align="left">
           <paper-listbox class="dropdown-content">
             <paper-item>allosaurus</paper-item>
             <paper-item>brontosaurus</paper-item>

--- a/demo/index.html
+++ b/demo/index.html
@@ -25,6 +25,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../paper-listbox/paper-listbox.html">
   <link rel="import" href="../../paper-tabs/paper-tabs.html">
   <link rel="import" href="../paper-dropdown-menu.html">
+  <link rel="import" href="../paper-dropdown-menu-light.html">
 
   <style is="custom-style" include="demo-pages-shared-styles">
     paper-tabs {
@@ -37,6 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     paper-dropdown-menu {
       width: 200px;
+      margin-right: 20px;
     }
   </style>
 
@@ -54,6 +56,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <paper-item>diplodocus</paper-item>
           </paper-listbox>
         </paper-dropdown-menu>
+
+        <paper-dropdown-menu-light label="Dinosaurs (light)">
+          <paper-listbox class="dropdown-content">
+            <paper-item>allosaurus</paper-item>
+            <paper-item>brontosaurus</paper-item>
+            <paper-item>carcharodontosaurus</paper-item>
+            <paper-item>diplodocus</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu-light>
       </template>
     </demo-snippet>
 
@@ -68,6 +79,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <paper-item>diplodocus</paper-item>
           </paper-listbox>
         </paper-dropdown-menu>
+
+        <paper-dropdown-menu-light label="Dinosaurs (light)">
+          <paper-listbox class="dropdown-content" selected="1">
+            <paper-item>allosaurus</paper-item>
+            <paper-item>brontosaurus</paper-item>
+            <paper-item>carcharodontosaurus</paper-item>
+            <paper-item>diplodocus</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu-light>
       </template>
     </demo-snippet>
 
@@ -82,6 +102,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <paper-item>diplodocus</paper-item>
           </paper-listbox>
         </paper-dropdown-menu>
+
+        <paper-dropdown-menu-light label="Upwards and to the left!" vertical-align="bottom" horizontal-align="left">
+          <paper-listbox class="dropdown-content">
+            <paper-item>allosaurus</paper-item>
+            <paper-item>brontosaurus</paper-item>
+            <paper-item>carcharodontosaurus</paper-item>
+            <paper-item>diplodocus</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu-light>
       </template>
     </demo-snippet>
 
@@ -97,6 +126,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <paper-item>diplodocus</paper-item>
           </paper-listbox>
         </paper-dropdown-menu>
+
+        <paper-dropdown-menu-light label="Disabled dinosaurs (light)" disabled>
+          <paper-listbox class="dropdown-content">
+            <paper-item>allosaurus</paper-item>
+            <paper-item>brontosaurus</paper-item>
+            <paper-item>carcharodontosaurus</paper-item>
+            <paper-item>diplodocus</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu-light>
       </template>
     </demo-snippet>
 
@@ -126,6 +164,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <paper-tab>emmental</paper-tab>
           </paper-tabs>
         </paper-dropdown-menu>
+
+        <paper-dropdown-menu-light label="Menu tabs!? (light)">
+          <paper-tabs class="dropdown-content">
+            <paper-tab>cheddar</paper-tab>
+            <paper-tab>stilton</paper-tab>
+            <paper-tab>emmental</paper-tab>
+          </paper-tabs>
+        </paper-dropdown-menu-light>
       </template>
     </demo-snippet>
 
@@ -140,6 +186,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <paper-item>diplodocus</paper-item>
           </paper-listbox>
         </paper-dropdown-menu>
+
+        <paper-dropdown-menu-light label="Dinosaurs (light)" noink no-animations>
+          <paper-listbox class="dropdown-content">
+            <paper-item>allosaurus</paper-item>
+            <paper-item>brontosaurus</paper-item>
+            <paper-item>carcharodontosaurus</paper-item>
+            <paper-item>diplodocus</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu-light>
       </template>
     </demo-snippet>
 
@@ -149,8 +204,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <style is="custom-style">
           paper-dropdown-menu.custom {
             --paper-input-container-label: {
-              color: white;
-              background-color: var(--paper-pink-500);
+              color: var(--paper-pink-500);
               font-style: italic;
               text-align: center;
               font-weight: bold;
@@ -166,6 +220,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               display: none;
             };
           }
+
+          paper-dropdown-menu-light.custom {
+            --paper-dropdown-menu-label: {
+              color: var(--paper-pink-500);
+              font-style: italic;
+              text-align: center;
+              font-weight: bold;
+            };
+            --paper-dropdown-menu-input: {
+              color: var(--paper-indigo-500);
+              font-style: normal;
+              font-family: serif;
+              text-transform: uppercase;
+              /* no underline */
+              border-bottom: none;
+            }
+          }
         </style>
         <paper-dropdown-menu class="custom" label="Custom" no-label-float>
           <paper-listbox class="dropdown-content">
@@ -175,6 +246,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <paper-item>diplodocus</paper-item>
           </paper-listbox>
         </paper-dropdown-menu>
+
+        <paper-dropdown-menu-light class="custom" label="Custom (light)" no-label-float>
+          <paper-listbox class="dropdown-content">
+            <paper-item>allosaurus</paper-item>
+            <paper-item>brontosaurus</paper-item>
+            <paper-item>carcharodontosaurus</paper-item>
+            <paper-item>diplodocus</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu-light>
       </template>
     </demo-snippet>
   </div>

--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -101,19 +101,19 @@ To style it:
       /**
        * All of these styles below are for styling the fake-input display
        */
-      .container {
+      .dropdown-trigger {
         box-sizing: border-box;
         position: relative;
         width: 100%;
         padding: 16px 0 8px 0;
       }
 
-      :host([disabled]) .container {
+      :host([disabled]) .dropdown-trigger {
         pointer-events: none;
         opacity: var(--paper-dropdown-menu-disabled-opacity, 0.33);
       }
 
-      :host([no-label-float]) .container {
+      :host([no-label-float]) .dropdown-trigger {
         padding-top: 8px;   /* If there's no label, we need less space up top. */
       }
 
@@ -260,12 +260,10 @@ To style it:
       on-iron-deselect="_onIronDeselect"
       opened="{{opened}}">
       <div class="dropdown-trigger">
-        <div class="container">
-          <label hidden$="[[!label]]"
-              class$="[[_computeLabelClass(noLabelFloat,alwaysFloatLabel,hasContent)]]">[[label]]</label>
-          <div id="input" tabindex="-1">&nbsp;</div>
-          <iron-icon icon="paper-dropdown-menu:arrow-drop-down"></iron-icon>
-        </div>
+        <label hidden$="[[!label]]"
+            class$="[[_computeLabelClass(noLabelFloat,alwaysFloatLabel,hasContent)]]">[[label]]</label>
+        <div id="input" tabindex="-1">&nbsp;</div>
+        <iron-icon icon="paper-dropdown-menu:arrow-drop-down"></iron-icon>
         <span class="error">[[errorMessage]]</span>
       </div>
       <content id="content" select=".dropdown-content"></content>

--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -1,6 +1,6 @@
 <!--
 @license
-Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
@@ -13,11 +13,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-behaviors/iron-button-state.html">
 <link rel="import" href="../iron-behaviors/iron-control-state.html">
 <link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
-<link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../iron-validatable-behavior/iron-validatable-behavior.html">
-<link rel="import" href="../paper-input/paper-input.html">
 <link rel="import" href="../paper-menu-button/paper-menu-button.html">
-<link rel="import" href="../paper-ripple/paper-ripple.html">
+<link rel="import" href="../paper-behaviors/paper-ripple-behavior.html">
 <link rel="import" href="../paper-styles/default-theme.html">
 
 <link rel="import" href="paper-dropdown-menu-icons.html">
@@ -26,21 +24,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <!--
 Material design: [Dropdown menus](https://www.google.com/design/spec/components/buttons.html#buttons-dropdown-buttons)
 
-`paper-dropdown-menu` is similar to a native browser select element.
-`paper-dropdown-menu` works with selectable content. The currently selected
+This is a faster, lighter version of `paper-dropdown-menu`, that does not
+use a `<paper-input>` internally. Use this element if you're concerned about
+the performance of this element, i.e., if you plan on using many dropdowns on
+the same page. Note that this element has a slightly different styling API
+than `paper-dropdown-menu`.
+
+`paper-dropdown-menu-light` is similar to a native browser select element.
+`paper-dropdown-menu-light` works with selectable content. The currently selected
 item is displayed in the control. If no item is selected, the `label` is
 displayed instead.
 
 Example:
 
-    <paper-dropdown-menu label="Your favourite pastry">
+    <paper-dropdown-menu-light label="Your favourite pastry">
       <paper-listbox class="dropdown-content">
         <paper-item>Croissant</paper-item>
         <paper-item>Donut</paper-item>
         <paper-item>Financier</paper-item>
         <paper-item>Madeleine</paper-item>
       </paper-listbox>
-    </paper-dropdown-menu>
+    </paper-dropdown-menu-light>
 
 This example renders a dropdown menu with 4 options.
 
@@ -67,22 +71,181 @@ Custom property | Description | Default
 `--paper-dropdown-menu-disabled` | A mixin that is applied to the element host when disabled | `{}`
 `--paper-dropdown-menu-ripple` | A mixin that is applied to the internal ripple | `{}`
 `--paper-dropdown-menu-button` | A mixin that is applied to the internal menu button | `{}`
-`--paper-dropdown-menu-input` | A mixin that is applied to the internal paper input | `{}`
 `--paper-dropdown-menu-icon` | A mixin that is applied to the internal icon | `{}`
+`--paper-dropdown-menu-disabled-opacity` | The opacity of the dropdown when disabled  | `0.33`
+`--paper-dropdown-menu-color` | The color of the input/label/underline when the dropdown is unfocused | `--primary-text-color`
+`--paper-dropdown-menu-focus-color` | The color of the label/underline when the dropdown is focused  | `--primary-color`
+`--paper-dropdown-error-color` | The color of the label/underline when the dropdown is invalid  | `--error-color`
+`--paper-dropdown-menu-label` | Mixin applied to the label | `{}`
+`--paper-dropdown-menu-input` | Mixin appled to the input | `{}`
 
-You can also use any of the `paper-input-container` and `paper-menu-button`
-style mixins and custom properties to style the internal input and menu button
-respectively.
+Note that in this element, the underline is just the bottom border of the "input".
+To style it:
+
+    <style is=custom-style>
+      paper-dropdown-menu-light.custom {
+        --paper-dropdown-menu-input: {
+          border-bottom: 2px dashed lavender;
+        };
+    </style>
 
 @group Paper Elements
-@element paper-dropdown-menu
+@element paper-dropdown-menu-light
 @hero hero.svg
 @demo demo/index.html
 -->
 
-<dom-module id="paper-dropdown-menu">
+<dom-module id="paper-dropdown-menu-light">
   <template>
-    <style include="paper-dropdown-menu-shared-styles"></style>
+    <style include="paper-dropdown-menu-shared-styles">
+      /**
+       * All of these styles below are for styling the fake-input display
+       */
+      .container {
+        box-sizing: border-box;
+        position: relative;
+        width: 100%;
+        padding: 16px 0 8px 0;
+      }
+
+      :host([disabled]) .container {
+        pointer-events: none;
+        opacity: var(--paper-dropdown-menu-disabled-opacity, 0.33);
+      }
+
+      :host([no-label-float]) .container {
+        padding-top: 8px;   /* If there's no label, we need less space up top. */
+      }
+
+      #input {
+        @apply(--paper-font-subhead);
+        border-bottom: 1px solid var(--paper-dropdown-menu-color, --secondary-text-color);
+        color: var(--paper-dropdown-menu-color, --primary-text-color);
+        padding: 12px 0 0 0;
+        width: 200px;  /* Default size of an <input> */
+        min-height: 24px;
+        white-space: nowrap;
+        outline: none;
+        @apply(--paper-dropdown-menu-input);
+      }
+
+      :host([disabled]) #input {
+        border-bottom: 1px dashed var(--paper-dropdown-menu-color, --secondary-text-color);
+      }
+
+      :host([invalid]) #input {
+        border-bottom: 2px solid var(--paper-dropdown-error-color, --error-color);
+      }
+
+      :host([no-label-float]) #input {
+        padding-top: 0;   /* If there's no label, we need less space up top. */
+      }
+
+      label {
+        @apply(--paper-font-common-nowrap);
+        @apply(--paper-font-subhead);
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        /**
+         * The container has a 16px top padding, and there's 12px of padding
+         * between the input and the label (from the input's padding-top)
+         */
+        top: 28px;
+        display: block;
+        width: 100%;
+        overflow: hidden;
+        white-space: nowrap;
+        text-align: left;
+        transition-duration: .2s;
+        transition-timing-function: cubic-bezier(.4,0,.2,1);
+        color: var(--paper-dropdown-menu-color, --secondary-text-color);
+        @apply(--paper-dropdown-menu-label);
+      }
+
+      :host([no-label-float]) label {
+        top: 8px;
+      }
+
+      label.label-is-floating {
+        font-size: 12px;
+        top: 8px;
+      }
+
+      label.label-is-hidden {
+        display: none;
+      }
+
+      :host([focused]) label.label-is-floating {
+        color: var(--paper-dropdown-menu-focus-color, --primary-color);
+      }
+
+      :host([invalid]) label.label-is-floating {
+        color: var(--paper-dropdown-error-color, --error-color);
+      }
+
+      /**
+       * Sets up the focused underline. It's initially hidden, and becomes
+       * visible when it's focused.
+       */
+      label:after {
+        background-color: var(--paper-dropdown-menu-focus-color, --primary-color);
+        bottom: 8px;    /* The container has an 8px bottom padding */
+        content: '';
+        height: 2px;
+        left: 45%;
+        position: absolute;
+        transition-duration: .2s;
+        transition-timing-function: cubic-bezier(.4,0,.2,1);
+        visibility: hidden;
+        width: 8px;
+        z-index: 10;
+      }
+
+      :host([invalid]) label:after {
+        background-color: var(--paper-dropdown-error-color, --error-color);
+      }
+
+      :host([no-label-float]) label:after {
+        bottom: 8px;    /* The container has a 8px bottom padding */
+      }
+
+      :host([focused]:not([disabled])) label:after {
+        left: 0;
+        visibility: visible;
+        width: 100%;
+      }
+
+      iron-icon {
+        position: absolute;
+        right: 0px;
+        bottom: 8px;    /* The container has an 8px bottom padding */
+        @apply(--paper-font-subhead);
+        margin-top: 12px;
+        color: var(--disabled-text-color);
+        @apply(--paper-dropdown-menu-icon);
+      }
+
+      :host([no-label-float]) iron-icon {
+        margin-top: 0px;
+      }
+
+      .error {
+        display: inline-block;
+        visibility: hidden;
+        color: var(--paper-dropdown-error-color, --error-color);
+        @apply(--paper-font-caption);
+        position: absolute;
+        left:0;
+        right:0;
+        bottom: -12px;
+      }
+
+      :host([invalid]) .error {
+        visibility: visible;
+      }
+    </style>
 
     <!-- this div fulfills an a11y requirement for combobox, do not remove -->
     <div role="button"></div>
@@ -97,21 +260,13 @@ respectively.
       on-iron-deselect="_onIronDeselect"
       opened="{{opened}}">
       <div class="dropdown-trigger">
-        <paper-ripple></paper-ripple>
-        <!-- paper-input has type="text" for a11y, do not remove -->
-        <paper-input
-          type="text"
-          invalid="[[invalid]]"
-          readonly
-          disabled="[[disabled]]"
-          value="[[selectedItemLabel]]"
-          placeholder="[[placeholder]]"
-          error-message="[[errorMessage]]"
-          always-float-label="[[alwaysFloatLabel]]"
-          no-label-float="[[noLabelFloat]]"
-          label="[[label]]">
-          <iron-icon icon="paper-dropdown-menu:arrow-drop-down" suffix></iron-icon>
-        </paper-input>
+        <div class="container">
+          <label hidden$="[[!label]]"
+              class$="[[_computeLabelClass(noLabelFloat,alwaysFloatLabel,hasContent)]]">[[label]]</label>
+          <div id="input" tabindex="-1">&nbsp;</div>
+          <iron-icon icon="paper-dropdown-menu:arrow-drop-down"></iron-icon>
+        </div>
+        <span class="error">[[errorMessage]]</span>
       </div>
       <content id="content" select=".dropdown-content"></content>
     </paper-menu-button>
@@ -122,11 +277,12 @@ respectively.
       'use strict';
 
       Polymer({
-        is: 'paper-dropdown-menu',
+        is: 'paper-dropdown-menu-light',
 
         behaviors: [
           Polymer.IronButtonState,
           Polymer.IronControlState,
+          Polymer.PaperRippleBehavior,
           Polymer.IronFormElementBehavior,
           Polymer.IronValidatableBehavior
         ],
@@ -164,7 +320,8 @@ respectively.
           value: {
             type: String,
             notify: true,
-            readOnly: true
+            readOnly: true,
+            observer: '_valueChanged',
           },
 
           /**
@@ -179,13 +336,6 @@ respectively.
            */
           placeholder: {
             type: String
-          },
-
-          /**
-           * The error message to display when invalid.
-           */
-          errorMessage: {
-              type: String
           },
 
           /**
@@ -242,6 +392,11 @@ respectively.
           verticalAlign: {
             type: String,
             value: 'top'
+          },
+
+          hasContent: {
+            type: Boolean,
+            readOnly: true
           }
         },
 
@@ -375,7 +530,32 @@ respectively.
           if (e) {
             e.setAttribute('aria-expanded', openState);
           }
-        }
+        },
+
+        _computeLabelClass: function(noLabelFloat, alwaysFloatLabel, hasContent) {
+          var cls = '';
+          if (noLabelFloat === true) {
+            return hasContent ? 'label-is-hidden' : '';
+          }
+
+          if (hasContent || alwaysFloatLabel === true) {
+            cls += ' label-is-floating';
+          }
+          return cls;
+        },
+
+        _valueChanged: function() {
+          // Only update if it's actually different.
+          if (this.$.input && this.$.input.textContent !== this.value) {
+            this.$.input.textContent = this.value;
+          }
+
+          if (this.value || this.value === 0 || this.value === false) {
+            this._setHasContent(true);
+          } else {
+            this._setHasContent(false);
+          }
+        },
       });
     })();
   </script>

--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -119,12 +119,13 @@ To style it:
 
       #input {
         @apply(--paper-font-subhead);
+        @apply(--paper-font-common-nowrap);
         border-bottom: 1px solid var(--paper-dropdown-menu-color, --secondary-text-color);
         color: var(--paper-dropdown-menu-color, --primary-text-color);
-        padding: 12px 0 0 0;
         width: 200px;  /* Default size of an <input> */
         min-height: 24px;
-        white-space: nowrap;
+        box-sizing: border-box;
+        padding: 12px 20px 0 0;   /* Right padding so that text doesn't overlap the icon */
         outline: none;
         @apply(--paper-dropdown-menu-input);
       }
@@ -142,8 +143,9 @@ To style it:
       }
 
       label {
-        @apply(--paper-font-common-nowrap);
         @apply(--paper-font-subhead);
+        @apply(--paper-font-common-nowrap);
+        display: block;
         position: absolute;
         bottom: 0;
         left: 0;
@@ -153,10 +155,9 @@ To style it:
          * between the input and the label (from the input's padding-top)
          */
         top: 28px;
-        display: block;
+        box-sizing: border-box;
         width: 100%;
-        overflow: hidden;
-        white-space: nowrap;
+        padding-right: 20px;    /* Right padding so that text doesn't overlap the icon */
         text-align: left;
         transition-duration: .2s;
         transition-timing-function: cubic-bezier(.4,0,.2,1);

--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -130,6 +130,11 @@ To style it:
         @apply(--paper-dropdown-menu-input);
       }
 
+      :host-context([dir="rtl"]) #input {
+        padding-right: 0px;
+        padding-left: 20px;
+      }
+
       :host([disabled]) #input {
         border-bottom: 1px dashed var(--paper-dropdown-menu-color, --secondary-text-color);
       }
@@ -163,6 +168,11 @@ To style it:
         transition-timing-function: cubic-bezier(.4,0,.2,1);
         color: var(--paper-dropdown-menu-color, --secondary-text-color);
         @apply(--paper-dropdown-menu-label);
+      }
+
+      :host-context([dir="rtl"]) label {
+        padding-right: 0px;
+        padding-left: 20px;
       }
 
       :host([no-label-float]) label {
@@ -226,6 +236,11 @@ To style it:
         margin-top: 12px;
         color: var(--disabled-text-color);
         @apply(--paper-dropdown-menu-icon);
+      }
+
+      :host-context([dir="rtl"]) iron-icon {
+        left: 0;
+        right: auto;
       }
 
       :host([no-label-float]) iron-icon {

--- a/paper-dropdown-menu-shared-styles.html
+++ b/paper-dropdown-menu-shared-styles.html
@@ -1,0 +1,79 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../paper-styles/default-theme.html">
+
+<dom-module id="paper-dropdown-menu-shared-styles">
+  <template>
+    <style>
+      :host {
+        display: inline-block;
+        position: relative;
+        text-align: left;
+        cursor: pointer;
+
+        /* NOTE(cdata): Both values are needed, since some phones require the
+         * value to be `transparent`.
+         */
+        -webkit-tap-highlight-color: rgba(0,0,0,0);
+        -webkit-tap-highlight-color: transparent;
+
+        --paper-input-container-input: {
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+          max-width: 100%;
+          box-sizing: border-box;
+          cursor: pointer;
+        };
+
+        @apply(--paper-dropdown-menu);
+      }
+
+      :host([disabled]) {
+        @apply(--paper-dropdown-menu-disabled);
+      }
+
+      :host([noink]) paper-ripple {
+        display: none;
+      }
+
+      :host([no-label-float]) paper-ripple {
+        top: 8px;
+      }
+
+      paper-ripple {
+        top: 12px;
+        left: 0px;
+        bottom: 8px;
+        right: 0px;
+
+        @apply(--paper-dropdown-menu-ripple);
+      }
+
+      paper-menu-button {
+        display: block;
+        padding: 0;
+
+        @apply(--paper-dropdown-menu-button);
+      }
+
+      paper-input {
+        @apply(--paper-dropdown-menu-input);
+      }
+
+      iron-icon {
+        color: var(--disabled-text-color);
+
+        @apply(--paper-dropdown-menu-icon);
+      }
+    </style>
+  </template>
+</dom-module>

--- a/test/index.html
+++ b/test/index.html
@@ -16,7 +16,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     WCT.loadSuites([
       'paper-dropdown-menu.html',
-      'paper-dropdown-menu.html?dom=shadow'
+      'paper-dropdown-menu.html?dom=shadow',
+      'paper-dropdown-menu-light.html',
+      'paper-dropdown-menu-light.html?dom=shadow'
     ]);
   </script>
 

--- a/test/paper-dropdown-menu-light.html
+++ b/test/paper-dropdown-menu-light.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>paper-dropdown-menu-light basic tests</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../test-fixture/test-fixture-mocha.js"></script>
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
+
+  <link rel="import" href="../../paper-listbox/paper-listbox.html">
+  <link rel="import" href="../../paper-item/paper-item.html">
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="../paper-dropdown-menu-light.html">
+</head>
+<body>
+
+  <test-fixture id="TrivialDropdownMenu">
+    <template>
+      <paper-dropdown-menu-light no-animations>
+        <paper-listbox class="dropdown-content">
+          <paper-item>Foo</paper-item>
+          <paper-item>Bar</paper-item>
+        </paper-listbox>
+      </paper-dropdown-menu-light>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="PreselectedDropdownMenu">
+    <template>
+      <paper-dropdown-menu-light no-animations>
+        <paper-listbox class="dropdown-content" selected="1">
+          <paper-item>Foo</paper-item>
+          <paper-item>Bar</paper-item>
+        </paper-listbox>
+      </paper-dropdown-menu-light>
+    </template>
+  </test-fixture>
+
+  <script>
+
+    function runAfterOpen(menu, callback) {
+      menu.$.menuButton.$.dropdown.addEventListener('iron-overlay-opened', function() {
+        Polymer.Base.async(callback, 1);
+      });
+      MockInteractions.tap(menu);
+    }
+
+    suite('<paper-dropdown-menu-light>', function() {
+      var dropdownMenu;
+
+      setup(function() {
+        dropdownMenu = fixture('TrivialDropdownMenu');
+        content = Polymer.dom(dropdownMenu).querySelector('.dropdown-content');
+      });
+
+      test('opens when tapped', function(done) {
+        var contentRect = content.getBoundingClientRect();
+
+        expect(contentRect.width).to.be.equal(0);
+        expect(contentRect.height).to.be.equal(0);
+
+        runAfterOpen(dropdownMenu, function() {
+          contentRect = content.getBoundingClientRect();
+
+          expect(dropdownMenu.opened).to.be.equal(true);
+
+          expect(contentRect.width).to.be.greaterThan(0);
+          expect(contentRect.height).to.be.greaterThan(0);
+          done();
+        });
+
+        expect(dropdownMenu.opened).to.be.equal(true);
+      });
+
+      test('closes when an item is activated', function(done) {
+        runAfterOpen(dropdownMenu, function() {
+          var firstItem = Polymer.dom(content).querySelector('paper-item');
+
+          MockInteractions.tap(firstItem);
+
+          Polymer.Base.async(function() {
+            expect(dropdownMenu.opened).to.be.equal(false);
+            done();
+          });
+        });
+      });
+
+      test('sets selected item to the activated item', function(done) {
+        runAfterOpen(dropdownMenu, function() {
+          var firstItem = Polymer.dom(content).querySelector('paper-item');
+
+          MockInteractions.tap(firstItem);
+
+          Polymer.Base.async(function() {
+            expect(dropdownMenu.selectedItem).to.be.equal(firstItem);
+            done();
+          });
+        });
+      });
+
+      suite('when a value is preselected', function() {
+        setup(function() {
+          dropdownMenu = fixture('PreselectedDropdownMenu');
+        });
+
+        test('the input area shows the correct selection', function() {
+          Polymer.dom.flush();
+          var secondItem = Polymer.dom(dropdownMenu).querySelectorAll('paper-item')[1];
+          expect(dropdownMenu.selectedItem).to.be.equal(secondItem);
+        });
+      });
+
+      suite('deselecting', function() {
+        var menu;
+
+        setup(function() {
+          dropdownMenu = fixture('PreselectedDropdownMenu');
+          menu = Polymer.dom(dropdownMenu).querySelector('.dropdown-content');
+        });
+
+        test('an `iron-deselect` event clears the current selection', function() {
+          Polymer.dom.flush();
+          menu.selected = null;
+          expect(dropdownMenu.selectedItem).to.be.equal(null);
+        });
+      });
+
+      suite('validation', function() {
+        test('a non required dropdown is valid regardless of its selection', function() {
+          var dropdownMenu = fixture('TrivialDropdownMenu');
+          menu = Polymer.dom(dropdownMenu).querySelector('.dropdown-content');
+
+          // no selection.
+          expect(dropdownMenu.validate()).to.be.true;
+          expect(dropdownMenu.invalid).to.be.false;
+          expect(dropdownMenu.value).to.not.be.ok;
+
+          // some selection.
+          menu.selected = 1;
+          expect(dropdownMenu.validate()).to.be.true;
+          expect(dropdownMenu.invalid).to.be.false;
+          expect(dropdownMenu.value).to.be.equal('Bar');
+        });
+
+        test('a required dropdown is invalid without a selection', function() {
+          var dropdownMenu = fixture('TrivialDropdownMenu');
+          dropdownMenu.required = true;
+
+          // no selection.
+          expect(dropdownMenu.validate()).to.be.false;
+          expect(dropdownMenu.invalid).to.be.true;
+          expect(dropdownMenu.value).to.not.be.ok;
+        });
+
+        test('a required dropdown is valid with a selection', function() {
+          var dropdownMenu = fixture('PreselectedDropdownMenu');
+          Polymer.dom.flush();
+
+          dropdownMenu.required = true;
+
+          expect(dropdownMenu.validate()).to.be.true;
+          expect(dropdownMenu.invalid).to.be.false;
+          expect(dropdownMenu.value).to.be.equal('Bar');
+        });
+      });
+    });
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
Put `paper-dropdown` on the treadmill:
- replace `paper-input` with a styled div. I had originally made this styled div a separate element (because it's got a bunch of styles), but since we had to bind down all the value/label/focused/disabled etc related properties this was actually a bit expensive. 
- add a lazy ripple for bonus points (because there's no reason we don't do this already; I'll add this to plain `paper-dropdown-menu` in a different PR

Code details to make review easier:
- most of the code is actually from `paper-dropdown-menu`. The only thing that is new is the `<div class="container` and its styles, `hasContent`, and the 2 private methods at the end
- all the tests are `100%` copied from `paper-dropdown-menu`
- I moved the styles to a separate file so they can be shared between the 2 implementations

I think this new element and the old one should behave in almost the same way (maybe minor differences re: styling, as we're using different mixins/custom properties). I've duplicated the demo and the tests to demonstrate this.

Results: 3.5x gain (the numbers are for 1k elements) 🎉🎉🎉 
<img width="425" alt="screen shot 2016-04-11 at 5 26 38 pm" src="https://cloud.githubusercontent.com/assets/1369170/14446401/a64e6928-000a-11e6-9fcd-e59636ac84ee.png">

Sanity check it looks the same (left: `paper-dropdown-menu`, right `paper-dropdown-menu-light`. The lavender is the entire dropdown `:host`):
<img width="413" alt="screen shot 2016-04-11 at 4 38 37 pm" src="https://cloud.githubusercontent.com/assets/1369170/14449122/b38150fa-0024-11e6-8282-b6decbf17a23.png">


/cc @cdata 