### PR TITLE
remove unused/vestigial paper-input code

### DIFF
--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -563,12 +563,7 @@ To style it:
           if (this.$.input && this.$.input.textContent !== this.value) {
             this.$.input.textContent = this.value;
           }
-
-          if (this.value || this.value === 0 || this.value === false) {
-            this._setHasContent(true);
-          } else {
-            this._setHasContent(false);
-          }
+          this._setHasContent(!!this.value);
         },
       });
     })();


### PR DESCRIPTION
`paper-dropdown-menu`'s value is always a string, so this isn't needed