### PR TITLE
Make noAnimations imply noink on the inner paper-ripple.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -178,7 +178,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <h4>You can remove the ripple and the animations</h4>
     <demo-snippet class="centered-demo">
       <template>
-        <paper-dropdown-menu label="Dinosaurs" noink no-animations>
+        <paper-dropdown-menu label="Dinosaurs" no-animations>
           <paper-listbox class="dropdown-content">
             <paper-item>allosaurus</paper-item>
             <paper-item>brontosaurus</paper-item>

--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -97,7 +97,7 @@ respectively.
       on-iron-deselect="_onIronDeselect"
       opened="{{opened}}">
       <div class="dropdown-trigger">
-        <paper-ripple></paper-ripple>
+        <paper-ripple noink="[[noAnimations]]"></paper-ripple>
         <!-- paper-input has type="text" for a11y, do not remove -->
         <paper-input
           type="text"


### PR DESCRIPTION
Fixes #102 where animation-free dropdowns ended up
with tons of Ripple objects endlessly and invisibly animating in
requestAnimationFrames, though I'll admit it's not a principled fix,
in that I'm not sure what the root cause of the bug is.

This seems to be roughly in line with user expectations I think, as
someone who doesn't want animations probably also doesn't want a
ripple animation.

I went this route rather than making `noink` work because the noink
property isn't mapped anywhere, and the requestAnimationFrame leak
would still occur for people using noAnimations.
