### PR TITLE
fix paper-dropdown-light styles

### DIFF
--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -102,6 +102,10 @@ To style it:
         outline: none;
       }
 
+      :host {
+        width: 200px;  /* Default size of an <input> */
+      }
+
       /**
        * All of these styles below are for styling the fake-input display
        */
@@ -126,7 +130,7 @@ To style it:
         @apply(--paper-font-common-nowrap);
         border-bottom: 1px solid var(--paper-dropdown-menu-color, --secondary-text-color);
         color: var(--paper-dropdown-menu-color, --primary-text-color);
-        width: 200px;  /* Default size of an <input> */
+        width: 100%;
         min-height: 24px;
         box-sizing: border-box;
         padding: 12px 20px 0 0;   /* Right padding so that text doesn't overlap the icon */
@@ -379,7 +383,7 @@ To style it:
             type: Boolean,
             value: false
           },
-          
+
           /**
            * Set to true to disable the floating label. Bind this to the
            * `<paper-input-container>`'s `noLabelFloat` property.

--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -128,10 +128,10 @@ To style it:
       #input {
         @apply(--paper-font-subhead);
         @apply(--paper-font-common-nowrap);
+        line-height: 1.5;
         border-bottom: 1px solid var(--paper-dropdown-menu-color, --secondary-text-color);
         color: var(--paper-dropdown-menu-color, --primary-text-color);
         width: 100%;
-        min-height: 24px;
         box-sizing: border-box;
         padding: 12px 20px 0 0;   /* Right padding so that text doesn't overlap the icon */
         outline: none;
@@ -242,7 +242,6 @@ To style it:
         right: 0px;
         bottom: 8px;    /* The container has an 8px bottom padding */
         @apply(--paper-font-subhead);
-        margin-top: 12px;
         color: var(--disabled-text-color);
         @apply(--paper-dropdown-menu-icon);
       }


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-dropdown-menu/issues/143

Also fixed how we centered the text and the icon: originally I used a `min-height` on the text, of the same height as the icon, but that's silly if you ever change the font size. Fixed that with some math.