### PR TITLE
div to span

### DIFF
--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -268,7 +268,7 @@ To style it:
     </style>
 
     <!-- this div fulfills an a11y requirement for combobox, do not remove -->
-    <div role="button"></div>
+    <span role="button"></span>
     <paper-menu-button
       id="menuButton"
       vertical-align="[[verticalAlign]]"

--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -85,7 +85,7 @@ respectively.
     <style include="paper-dropdown-menu-shared-styles"></style>
 
     <!-- this div fulfills an a11y requirement for combobox, do not remove -->
-    <div role="button"></div>
+    <span role="button"></span>
     <paper-menu-button
       id="menuButton"
       vertical-align="[[verticalAlign]]"


### PR DESCRIPTION
Fixes #153 by changing the `role="button"` to be a `span` rather than a `div`, so that a `:before` pseudo element can be rendered on the left of the internal `paper-menu-button` http://jsbin.com/fegoho/4/edit?html,output