### PR TITLE
Add ignoreSelect property. Fixes #53

### DIFF
--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -271,6 +271,7 @@ To style it:
     <div role="button"></div>
     <paper-menu-button
       id="menuButton"
+      ignore-select="[[ignoreSelect]]"
       vertical-align="[[verticalAlign]]"
       horizontal-align="[[horizontalAlign]]"
       vertical-offset="[[_computeMenuVerticalOffset(noLabelFloat)]]"
@@ -410,6 +411,15 @@ To style it:
           verticalAlign: {
             type: String,
             value: 'top'
+          },
+
+          /**
+           * Set to true to disable automatically closing the dropdown after
+           * a selection has been made.
+           */
+          ignoreSelect: {
+            type: Boolean,
+            value: false
           },
 
           hasContent: {

--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -88,6 +88,7 @@ respectively.
     <div role="button"></div>
     <paper-menu-button
       id="menuButton"
+      ignore-select="[[ignoreSelect]]"
       vertical-align="[[verticalAlign]]"
       horizontal-align="[[horizontalAlign]]"
       vertical-offset="[[_computeMenuVerticalOffset(noLabelFloat)]]"
@@ -242,6 +243,15 @@ respectively.
           verticalAlign: {
             type: String,
             value: 'top'
+          },
+
+          /**
+           * Set to true to disable automatically closing the dropdown after
+           * a selection has been made.
+           */
+          ignoreSelect: {
+            type: Boolean,
+            value: false
           }
         },
 

--- a/test/paper-dropdown-menu-light.html
+++ b/test/paper-dropdown-menu-light.html
@@ -110,6 +110,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
+      test('sets ignoreSelect property on the contained paper-menu-button', function() {
+        dropdownMenu.ignoreSelect = true;
+        expect(dropdownMenu.$.menuButton.ignoreSelect).to.be.equal(true);
+      });
+
       suite('when a value is preselected', function() {
         setup(function() {
           dropdownMenu = fixture('PreselectedDropdownMenu');

--- a/test/paper-dropdown-menu.html
+++ b/test/paper-dropdown-menu.html
@@ -111,6 +111,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
+      test('sets ignoreSelect property on the contained paper-menu-button', function() {
+        dropdownMenu.ignoreSelect = true;
+        expect(dropdownMenu.$.menuButton.ignoreSelect).to.be.equal(true);
+      });
+
       suite('when a value is preselected', function() {
         setup(function() {
           dropdownMenu = fixture('PreselectedDropdownMenu');


### PR DESCRIPTION
Establish ignoreSelect property for paper-dropdown-menu as bound to the inner paper-menu-button's ignoreSelect property.
