### PR TITLE
Follow up to #131, which was created before paper-dropdown-menu-light.

### DIFF
--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -522,7 +522,7 @@ To style it:
           if (!selectedItem) {
             value = '';
           } else {
-            value = selectedItem.label || selectedItem.textContent.trim();
+            value = selectedItem.label || selectedItem.getAttribute('label') || selectedItem.textContent.trim();
           }
 
           this._setValue(value);

--- a/test/paper-dropdown-menu-light.html
+++ b/test/paper-dropdown-menu-light.html
@@ -48,6 +48,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="LabelsDropdownMenu">
+    <template>
+      <paper-dropdown-menu-light no-animations>
+        <paper-listbox class="dropdown-content">
+          <paper-item label="Foo label property">Foo textContent</paper-item>
+          <paper-item label="Foo label attribute">Foo textContent</paper-item>
+          <paper-item>Foo textContent</paper-item>
+        </paper-listbox>
+      </paper-dropdown-menu-light>
+    </template>
+  </test-fixture>
+
   <script>
 
     function runAfterOpen(menu, callback) {
@@ -173,6 +185,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(dropdownMenu.validate()).to.be.true;
           expect(dropdownMenu.invalid).to.be.false;
           expect(dropdownMenu.value).to.be.equal('Bar');
+        });
+      });
+
+      suite('selectedItemLabel', function() {
+        test('label property', function() {
+          var dropdownMenu = fixture('LabelsDropdownMenu');
+          var menu = Polymer.dom(dropdownMenu).querySelector('.dropdown-content');
+          menu.selected = 0;
+          //Fake a label property since paper-item doesn't have one
+          dropdownMenu.selectedItem.label = dropdownMenu.selectedItem.getAttribute('label');
+          expect(dropdownMenu.selectedItemLabel).to.be.equal('Foo label property');
+        });
+
+        test('label attribute', function() {
+          var dropdownMenu = fixture('LabelsDropdownMenu');
+          var menu = Polymer.dom(dropdownMenu).querySelector('.dropdown-content');
+          menu.selected = 1;
+          expect(dropdownMenu.selectedItemLabel).to.be.equal('Foo label attribute');
+        });
+
+        test('textContent', function() {
+          var dropdownMenu = fixture('LabelsDropdownMenu');
+          var menu = Polymer.dom(dropdownMenu).querySelector('.dropdown-content');
+          menu.selected = 2;
+          expect(dropdownMenu.selectedItemLabel).to.be.equal('Foo textContent');
         });
       });
     });


### PR DESCRIPTION
This is copy-pasted from @miztroh's contribution in #131 + `s/paper-dropdown-menu/\0-light/g`.