### PR TITLE
Fixes #85: Expose `dynamicAlign`, `noOverlap`.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
     "iron-iconset-svg": "polymerelements/iron-iconset-svg#^1.0.0",
     "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^1.0.0",
+    "iron-fit-behavior": "PolymerElements/iron-fit-behavior#^1.2.0",
     "paper-behaviors": "PolymerElements/paper-behaviors#^1.0.0",
     "paper-input": "PolymerElements/paper-input#^1.0.9",
     "paper-menu-button": "PolymerElements/paper-menu-button#^1.3.0",

--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -274,6 +274,8 @@ To style it:
       vertical-align="[[verticalAlign]]"
       horizontal-align="[[horizontalAlign]]"
       vertical-offset="[[_computeMenuVerticalOffset(noLabelFloat)]]"
+      dynamic-align="[[dynamicAlign]]"
+      no-overlap="[[noOverlap]]"
       disabled="[[disabled]]"
       no-animations="[[noAnimations]]"
       on-iron-select="_onIronSelect"
@@ -423,6 +425,24 @@ To style it:
           verticalAlign: {
             type: String,
             value: 'top'
+          },
+
+          /**
+           * If true, the `horizontalAlign` and `verticalAlign` properties will
+           * be considered preferences instead of strict requirements when
+           * positioning the dropdown and may be changed if doing so reduces
+           * the area of the dropdown falling outside of `fitInto`.
+           */
+          dynamicAlign: {
+            type: Boolean
+          },
+
+          /**
+           * If true, the dropdown will be positioned so that it doesn't overlap
+           * the button.
+           */
+          noOverlap: {
+            type: Boolean
           },
 
           hasContent: {

--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -91,6 +91,8 @@ respectively.
       vertical-align="[[verticalAlign]]"
       horizontal-align="[[horizontalAlign]]"
       vertical-offset="[[_computeMenuVerticalOffset(noLabelFloat)]]"
+      dynamic-align="[[dynamicAlign]]"
+      no-overlap="[[noOverlap]]"
       disabled="[[disabled]]"
       no-animations="[[noAnimations]]"
       on-iron-select="_onIronSelect"
@@ -255,6 +257,24 @@ respectively.
           verticalAlign: {
             type: String,
             value: 'top'
+          },
+
+          /**
+           * If true, the `horizontalAlign` and `verticalAlign` properties will
+           * be considered preferences instead of strict requirements when
+           * positioning the dropdown and may be changed if doing so reduces
+           * the area of the dropdown falling outside of `fitInto`.
+           */
+          dynamicAlign: {
+            type: Boolean
+          },
+
+          /**
+           * If true, the dropdown will be positioned so that it doesn't overlap
+           * the button.
+           */
+          noOverlap: {
+            type: Boolean
           }
         },
 


### PR DESCRIPTION
~~Depends on PolymerElements/paper-menu-button#96.~~ (merged)

(Fixes #85.)
