### PR TITLE
fix focus underline when there's no label

### DIFF
--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -186,6 +186,9 @@ To style it:
 
       :host([no-label-float]) label {
         top: 8px;
+        /* Since the label doesn't need to float, remove the animation duration
+        which slows down visibility changes (i.e. when a selection is made) */
+        transition-duration: 0s;
       }
 
       label.label-is-floating {
@@ -194,7 +197,7 @@ To style it:
       }
 
       label.label-is-hidden {
-        display: none;
+        visibility: hidden;
       }
 
       :host([focused]) label.label-is-floating {


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-dropdown-menu/issues/181
- the original `<label>` used `visibility`, not `display:none` when floating the label. This makes sense for this case too, since `display:none`-ing the label will also remove the `:after`, which is the underline
- removed the animation duration if the label doesn't need to float, as this lead to a brief 0.2s of text overlap between the label and the selected text

PTAL @bicknellr, cc @mgiuffrida 