### PR TITLE
Add option to set a specific value sent to the server for each option

### DIFF
--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -346,14 +346,14 @@ respectively.
          */
         _selectedItemChanged: function(selectedItem) {
           var value = '';
-          if (!selectedItem) {
-            value = '';
-          } else {
-            value = selectedItem.label || selectedItem.getAttribute('label') || selectedItem.textContent.trim();
+          var labelValue = '';
+          if (selectedItem) {
+            value = selectedItem.getAttribute('value') || selectedItem.label || selectedItem.getAttribute('label') || selectedItem.textContent.trim();
+            labelValue = selectedItem.label || selectedItem.getAttribute('label') || selectedItem.textContent.trim();
           }
 
           this._setValue(value);
-          this._setSelectedItemLabel(value);
+          this._setSelectedItemLabel(labelValue);
         },
 
         /**


### PR DESCRIPTION
At the moment, if you have a dropdown menu like this:

            <paper-dropdown-menu name="country" id="country" label="Your country">
              <paper-listbox attr-for-selected="choice" selected="[[countryDefault]]" class="dropdown-content">
                <paper-item choice="it">Italy</paper-item>
                <paper-item choice="fr">France</paper-item>
                <paper-item choice="">Other</paper-item>
              </paper-listbox>
            </paper-dropdown-menu>

After submitting, the server will receive "Italy", "France" or "". There is no way, at the moment, for it to behave like a native select box:

    <select>
      <option value="it">Italy</option>
      <option value="fr">France</option>
      <option value="">Other</option>
  </select>

The only option to send the right data to the server is by setting the "label" attribute for the various <paper-items> elements. However, this has the side effect that after making the selection, the user will see "it", "fr" etc.

This patch addresses that: if `value` is set for the selected item, THAT is the value considered and assigned to the paper-dropdown-menu.

I wouldn't have tortured you with a PR if I had found a way to do this in other ways... sorry!