### PR TITLE
Remove the cursor pointer setting

### DIFF
--- a/paper-dropdown-menu-shared-styles.html
+++ b/paper-dropdown-menu-shared-styles.html
@@ -17,7 +17,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         display: inline-block;
         position: relative;
         text-align: left;
-        cursor: pointer;
 
         /* NOTE(cdata): Both values are needed, since some phones require the
          * value to be `transparent`.


### PR DESCRIPTION
The mouse cursor pointer settings are nicer to have on the paper-menu-button instead of the paper-dropdown-menu. Setting the cursor here cascades into the scroll bar of the dropdown content. It's nicer to set the cursor to pointer in just the trigger within the paper-menu-button.