### PR TITLE
restore input to default if no element is selected

### DIFF
--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -434,7 +434,8 @@ To style it:
 
           hasContent: {
             type: Boolean,
-            readOnly: true
+            readOnly: true,
+            observer: '_hasContentChanged'
           }
         },
 
@@ -589,6 +590,12 @@ To style it:
             this.$.input.textContent = this.value;
           }
           this._setHasContent(!!this.value);
+        },
+
+        _hasContentChanged: function (hasContent) {
+          if (!hasContent && this.$.input){
+            this.$.input.innerHTML = "&nbsp;";
+          }
         },
       });
     })();


### PR DESCRIPTION
The `paper-dropdown-menu-light` shows label out of place when an item is selected and then all items are removed. i.e. Binding items to a firebase-query or any other dynamic source.

## Expected outcome
`paper-dropdown-menu-light` should return to its default state if all content is removed.

## Actual outcome
After items get deleted, the innerHTML of `<div id="input"...` is empty, instead of `&nbsp;`, which makes the div smaller and causes the label to show out of place.

## Steps to reproduce
1. Put a `paper-dropdown-menu-light` on the page.
2. Put a `paper-menu` inside with `class="dropdown-content"`.
3. Put a `<template is="dom-repeat" ..` inside with `items` pointing to an `array`
4. Select an element from the dropdown.
5. Remove all elements from the `array` using the corresponding array mutation methods.

**Test case:** https://jsbin.com/qufitil/edit?html,output