### PR TITLE
Fixes #218

### DIFF
--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -285,6 +285,7 @@ To style it:
       no-animations="[[noAnimations]]"
       on-iron-select="_onIronSelect"
       on-iron-deselect="_onIronDeselect"
+      fit-into="[[fitInto]]"
       opened="{{opened}}"
       close-on-activate
       allow-outside-scroll="[[allowOutsideScroll]]">
@@ -422,6 +423,13 @@ To style it:
           horizontalAlign: {
             type: String,
             value: 'right'
+          },
+
+          /**
+           * The element to fit `this` into.
+           */
+          fitInto: {
+            type: Object
           },
 
           /**

--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -97,6 +97,7 @@ respectively.
       on-iron-select="_onIronSelect"
       on-iron-deselect="_onIronDeselect"
       opened="{{opened}}"
+      fit-into="[[fitInto]]"
       close-on-activate
       allow-outside-scroll="[[allowOutsideScroll]]">
       <div class="dropdown-trigger">
@@ -256,6 +257,13 @@ respectively.
           verticalAlign: {
             type: String,
             value: 'top'
+          },
+
+          /**
+           * The element to fit `this` into.
+           */
+          fitInto: {
+            type: Object
           },
 
           /**


### PR DESCRIPTION
Expose `fit-into` default this is `window` but in some cases you want to use another `fit-into` target. This is in general handy when you’re using `dynamic-align=true` and the element where you want your
`paper-dropdown-menu` want to fit into  is _not_ `window`
This only will work if issue [108 of paper-menu-button](https://github.com/PolymerElements/paper-menu-button/issues/108) is fixed, because `paper-dropdown-menu` is using `paper-menu-button`