### PR TITLE
Remove deprecated `version` field from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "paper-dropdown-menu",
-  "version": "1.4.3",
   "description": "An element that works similarly to a native browser select",
   "authors": [
     "The Polymer Authors"


### PR DESCRIPTION
Version is deprecated and ignored by Bower: https://github.com/bower/spec/blob/master/json.md#version