### PR TITLE
Allow restoreFocusOnClose to be set on paper-dropdown-menu

### DIFF
--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -98,7 +98,8 @@ respectively.
       on-iron-deselect="_onIronDeselect"
       opened="{{opened}}"
       close-on-activate
-      allow-outside-scroll="[[allowOutsideScroll]]">
+      allow-outside-scroll="[[allowOutsideScroll]]"
+      restore-focus-on-close="[[restoreFocusOnClose]]">
       <div class="dropdown-trigger">
         <paper-ripple></paper-ripple>
         <!-- paper-input has type="text" for a11y, do not remove -->
@@ -266,6 +267,14 @@ respectively.
            */
           dynamicAlign: {
             type: Boolean
+          },
+            
+          /**
+           * Whether focus should be restored to the dropdown when the menu closes.
+           */
+          restoreFocusOnClose: {
+            type: Boolean,
+            value: true
           },
         },
 


### PR DESCRIPTION
Paper-dropdown-menu creates a child paper-menu-button.  Paper-menu-button has a restore-focus-on-close property, but there is currently no way for components with a paper-dropdown-menu to set this property.  This will allow components with a paper-dropdown-menu to choose not to have focus set on the menu when the menu closes.