### PR TITLE
Allow restoreFocusOnClose to be set on paper-dropdown-menu-lite

### DIFF
--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -287,7 +287,8 @@ To style it:
       on-iron-deselect="_onIronDeselect"
       opened="{{opened}}"
       close-on-activate
-      allow-outside-scroll="[[allowOutsideScroll]]">
+      allow-outside-scroll="[[allowOutsideScroll]]"
+      restore-focus-on-close="[[restoreFocusOnClose]]">
       <div class="dropdown-trigger">
         <label class$="[[_computeLabelClass(noLabelFloat,alwaysFloatLabel,hasContent)]]">
           [[label]]
@@ -436,7 +437,15 @@ To style it:
           hasContent: {
             type: Boolean,
             readOnly: true
-          }
+          },
+
+          /**
+           * Whether focus should be restored to the dropdown when the menu closes.
+           */
+          restoreFocusOnClose: {
+            type: Boolean,
+            value: true
+          },
         },
 
         listeners: {


### PR DESCRIPTION
See https://github.com/PolymerElements/paper-dropdown-menu/pull/227 for the same change on paper-dropdown-menu.