### PR TITLE
from polymerelements to PolymerElements in 2.0-preview

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#2.0-preview",
     "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#2.0-preview",
     "iron-icon": "PolymerElements/iron-icon#2.0-preview",
-    "iron-iconset-svg": "polymerelements/iron-iconset-svg#2.0-preview",
+    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#2.0-preview",
     "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#2.0-preview",
     "paper-behaviors": "PolymerElements/paper-behaviors#2.0-preview",
     "paper-input": "PolymerElements/paper-input#2.0-preview",


### PR DESCRIPTION
This pull request wants to make this Polymer element consistent with the majority of other Polymer elements in the 2.0-preview branch. The uppercase version "PolymerElements" is closer to real name of the github project name, like presented in the git URL.

The use of mixed case does not seem to have an effect on bower and JavaScript projects. But other languages like Java are more picky and would benefit from consistency.

I fixed this in the  "2.0-preview" branch of this element, because it would be very nice to have this cleaned up and consistent in 2.0 release. I have manually checked 66 elements that have a "2.0-preview" branch. 56 are ok. This element is one of 10 which has these small differences.

This pull request is a manual follow up of PolymerLabs/tedium#47 and PolymerLabs/tedium#48 which try to do this in an automated way, but are stuck.
