### PR TITLE
Added reference to specific slot declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Published on webcomponents.org](https://img.shields.io/badge/webcomponents.org-published-blue.svg)](https://beta.webcomponents.org/element/PolymerElements/paper-dropdown-menu)
 [![Build status](https://travis-ci.org/PolymerElements/paper-dropdown-menu.svg?branch=master)](https://travis-ci.org/PolymerElements/paper-dropdown-menu)
 
-##&lt;paper-dropdown-menu&gt;
+# \<paper-dropdown-menu\>
 
 Material design: [Dropdown menus](https://www.google.com/design/spec/components/buttons.html#buttons-dropdown-buttons)
 
@@ -32,6 +32,11 @@ Material design: [Dropdown menus](https://www.google.com/design/spec/components/
 </custom-element-demo>
 ```
 -->
+
+## Examples
+
+In Polymer 1 the content of the dropdown should be a `paper-listbox` with `class="dropdown-content"`
+
 ```html
 <paper-dropdown-menu label="Dinosaurs">
   <paper-listbox class="dropdown-content" selected="1">
@@ -42,3 +47,17 @@ Material design: [Dropdown menus](https://www.google.com/design/spec/components/
   </paper-listbox>
 </paper-dropdown-menu>
 ```
+
+In Polymer 2 specify `slot="dropdown-content"` instead:
+
+```html
+<paper-dropdown-menu label="Dinosaurs">
+  <paper-listbox slot="dropdown-content" selected="1">
+    <paper-item>allosaurus</paper-item>
+    <paper-item>brontosaurus</paper-item>
+    <paper-item>carcharodontosaurus</paper-item>
+    <paper-item>diplodocus</paper-item>
+  </paper-listbox>
+</paper-dropdown-menu>
+```
+


### PR DESCRIPTION
Specific slot declaration is required by Polymer 2 (https://github.com/PolymerElements/paper-dropdown-menu/issues/242#issuecomment-294509230), but is not currently referenced by documentation.  
Also fixed heading formatting