### PR TITLE
Adds prefix slot that gets passed to paper-input.

### DIFF
--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -115,6 +115,7 @@ respectively.
           always-float-label="[[alwaysFloatLabel]]"
           no-label-float="[[noLabelFloat]]"
           label="[[label]]">
+          <slot name="prefix" slot="prefix"></slot>
           <!-- support hybrid mode: user might be using paper-input 1.x which distributes via <content> -->
           <iron-icon icon="paper-dropdown-menu:arrow-drop-down" suffix slot="suffix"></iron-icon>
         </paper-input>


### PR DESCRIPTION
Allows you to prefix stuff such as icons or emoji 😉 in the same way you can with a paper-input.  Now your forms can have a consistent look with prefix icons.