### PR TITLE
Add option to pass custom value to vertical offset

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -200,6 +200,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </demo-snippet>
 
+    <h4>You can override the vertical offset to position it below the button</h4>
+    <demo-snippet class="centered-demo">
+      <template>
+        <paper-dropdown-menu label="Dinosaurs" vertical-offset="60">
+          <paper-listbox slot="dropdown-content" class="dropdown-content" selected="1">
+            <paper-item>allosaurus</paper-item>
+            <paper-item>brontosaurus</paper-item>
+            <paper-item>carcharodontosaurus</paper-item>
+            <paper-item>diplodocus</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu>
+
+        <paper-dropdown-menu-light label="Dinosaurs (light)" vertical-offset="60">
+          <paper-listbox slot="dropdown-content" class="dropdown-content" selected="1">
+            <paper-item>allosaurus</paper-item>
+            <paper-item>brontosaurus</paper-item>
+            <paper-item>carcharodontosaurus</paper-item>
+            <paper-item>diplodocus</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu-light>
+      </template>
+    </demo-snippet>
+
     <h4>You can style a paper-dropdown-menu using custom properties</h4>
     <demo-snippet class="centered-demo">
       <template>

--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -286,7 +286,7 @@ To style it:
       id="menuButton"
       vertical-align="[[verticalAlign]]"
       horizontal-align="[[horizontalAlign]]"
-      vertical-offset="[[_computeMenuVerticalOffset(noLabelFloat)]]"
+      vertical-offset="[[_computeMenuVerticalOffset(noLabelFloat, verticalOffset)]]"
       disabled="[[disabled]]"
       no-animations="[[noAnimations]]"
       on-iron-select="_onIronSelect"
@@ -440,6 +440,12 @@ To style it:
             value: 'top'
           },
 
+          /**
+           * Overrides the vertical offset computed in
+           * _computeMenuVerticalOffset.
+           */
+          verticalOffset: Number,
+
           hasContent: {
             type: Boolean,
             readOnly: true
@@ -556,9 +562,13 @@ To style it:
          * `noLabelFloat`.
          *
          * @param {boolean} noLabelFloat True if the label should not float
+         * @param {number=} opt_verticalOffset Optional offset from the user
          * above the input, otherwise false.
          */
-        _computeMenuVerticalOffset: function(noLabelFloat) {
+         _computeMenuVerticalOffset: function(noLabelFloat, opt_verticalOffset) {
+          // Override offset if it's passed from the user.
+          if (opt_verticalOffset) { return opt_verticalOffset; }
+
           // NOTE(cdata): These numbers are somewhat magical because they are
           // derived from the metrics of elements internal to `paper-input`'s
           // template. The metrics will change depending on whether or not the

--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -91,7 +91,7 @@ respectively.
       vertical-align="[[verticalAlign]]"
       horizontal-align="[[horizontalAlign]]"
       dynamic-align="[[dynamicAlign]]"
-      vertical-offset="[[_computeMenuVerticalOffset(noLabelFloat)]]"
+      vertical-offset="[[_computeMenuVerticalOffset(noLabelFloat, verticalOffset)]]"
       disabled="[[disabled]]"
       no-animations="[[noAnimations]]"
       on-iron-select="_onIronSelect"
@@ -262,6 +262,12 @@ respectively.
           },
 
           /**
+           * Overrides the vertical offset computed in
+           * _computeMenuVerticalOffset.
+           */
+           verticalOffset: Number,
+
+          /**
            * If true, the `horizontalAlign` and `verticalAlign` properties will
            * be considered preferences instead of strict requirements when
            * positioning the dropdown and may be changed if doing so reduces
@@ -270,7 +276,7 @@ respectively.
           dynamicAlign: {
             type: Boolean
           },
-            
+
           /**
            * Whether focus should be restored to the dropdown when the menu closes.
            */
@@ -389,9 +395,13 @@ respectively.
          * `noLabelFloat`.
          *
          * @param {boolean} noLabelFloat True if the label should not float
+         * @param {number=} opt_verticalOffset Optional offset from the user
          * above the input, otherwise false.
          */
-        _computeMenuVerticalOffset: function(noLabelFloat) {
+        _computeMenuVerticalOffset: function(noLabelFloat, opt_verticalOffset) {
+          // Override offset if it's passed from the user.
+          if (opt_verticalOffset) { return opt_verticalOffset; }
+
           // NOTE(cdata): These numbers are somewhat magical because they are
           // derived from the metrics of elements internal to `paper-input`'s
           // template. The metrics will change depending on whether or not the


### PR DESCRIPTION
This lets the user position the dropdown content below the trigger. If a
vertical offset is not provided, it gets computed as it was previously.