### PR TITLE
Add 'ignoreSelect'

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -259,6 +259,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </paper-dropdown-menu-light>
       </template>
     </demo-snippet>
+
+    <h4>This is a multiselect paper-dropdown-menu</h4>
+    <demo-snippet class="centered-demo">
+      <template>
+        <paper-dropdown-menu label="Dinosaurs" ignore-select>
+          <paper-listbox slot="dropdown-content" class="dropdown-content" multi>
+            <paper-item>allosaurus</paper-item>
+            <paper-item>brontosaurus</paper-item>
+            <paper-item>carcharodontosaurus</paper-item>
+            <paper-item>diplodocus</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu>
+
+        <paper-dropdown-menu-light label="Dinosaurs (light)" ignore-select>
+          <paper-listbox slot="dropdown-content" class="dropdown-content" multi>
+            <paper-item>allosaurus</paper-item>
+            <paper-item>brontosaurus</paper-item>
+            <paper-item>carcharodontosaurus</paper-item>
+            <paper-item>diplodocus</paper-item>
+          </paper-listbox>
+        </paper-dropdown-menu-light>
+      </template>
+    </demo-snippet>
   </div>
 
   <script>

--- a/paper-dropdown-menu-light.html
+++ b/paper-dropdown-menu-light.html
@@ -292,8 +292,8 @@ To style it:
       on-iron-select="_onIronSelect"
       on-iron-deselect="_onIronDeselect"
       opened="{{opened}}"
-      close-on-activate
-      allow-outside-scroll="[[allowOutsideScroll]]">
+      allow-outside-scroll="[[allowOutsideScroll]]"
+      ignore-select="[[ignoreSelect]]">
       <!-- support hybrid mode: user might be using paper-menu-button 1.x which distributes via <content> -->
       <div class="dropdown-trigger" slot="dropdown-trigger">
         <label class$="[[_computeLabelClass(noLabelFloat,alwaysFloatLabel,hasContent)]]">
@@ -443,6 +443,15 @@ To style it:
           hasContent: {
             type: Boolean,
             readOnly: true
+          },
+
+          /**
+           * Set to true to disable automatically closing the dropdown after
+           * a selection has been made.
+           */
+          ignoreSelect: {
+            type: Boolean,
+            value: false
           }
         },
 

--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -97,9 +97,9 @@ respectively.
       on-iron-select="_onIronSelect"
       on-iron-deselect="_onIronDeselect"
       opened="{{opened}}"
-      close-on-activate
       allow-outside-scroll="[[allowOutsideScroll]]"
-      restore-focus-on-close="[[restoreFocusOnClose]]">
+      restore-focus-on-close="[[restoreFocusOnClose]]"
+      ignore-select="[[ignoreSelect]]">
       <!-- support hybrid mode: user might be using paper-menu-button 1.x which distributes via <content> -->
       <div class="dropdown-trigger" slot="dropdown-trigger">
         <paper-ripple></paper-ripple>
@@ -278,6 +278,15 @@ respectively.
             type: Boolean,
             value: true
           },
+
+          /**
+           * Set to true to disable automatically closing the dropdown after
+           * a selection has been made.
+           */
+          ignoreSelect: {
+            type: Boolean,
+            value: false
+          }
         },
 
         listeners: {

--- a/test/paper-dropdown-menu-light.html
+++ b/test/paper-dropdown-menu-light.html
@@ -58,6 +58,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="MultiselectDropdownMenu">
+    <template>
+      <paper-dropdown-menu-light no-animations ignore-select>
+        <paper-listbox slot="dropdown-content" class="dropdown-content" selected-values="[0,1]" multi>
+          <paper-item>Foo</paper-item>
+          <paper-item>Bar</paper-item>
+          <paper-item>Baz</paper-item>
+        </paper-listbox>
+      </paper-dropdown-menu-light>
+    </template>
+  </test-fixture>
+
   <script>
 
     function runAfterOpen(dropdownMenu, callback) {
@@ -223,6 +235,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('textContent', function() {
           content.selected = 2;
           expect(dropdownMenu.selectedItemLabel).to.be.equal('Foo textContent');
+        });
+      });
+
+      suite('multiselect', function() {
+        setup(function(done) {
+          dropdownMenu = fixture('MultiselectDropdownMenu');
+          content = Polymer.dom(dropdownMenu).querySelector('[slot="dropdown-content"]');
+          // Wait for distribution.
+          Polymer.Base.async(function() {
+            done();
+          });
+        });
+
+        test('makes multiple selections', function() {
+          expect(content.selectedValues.length).to.be.equal(2);
+        });
+
+        test('ignores select', function() {
+          expect(dropdownMenu.ignoreSelect).to.be.true;
         });
       });
     });

--- a/test/paper-dropdown-menu.html
+++ b/test/paper-dropdown-menu.html
@@ -58,6 +58,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="MultiselectDropdownMenu">
+    <template>
+      <paper-dropdown-menu no-animations ignore-select>
+        <paper-listbox slot="dropdown-content" class="dropdown-content" selected-values="[0,1]" multi>
+          <paper-item>Foo</paper-item>
+          <paper-item>Bar</paper-item>
+          <paper-item>Baz</paper-item>
+        </paper-listbox>
+      </paper-dropdown-menu>
+    </template>
+  </test-fixture>
+
   <script>
 
     function runAfterOpen(dropdownMenu, callback) {
@@ -223,6 +235,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('textContent', function() {
           content.selected = 2;
           expect(dropdownMenu.selectedItemLabel).to.be.equal('Foo textContent');
+        });
+      });
+
+      suite('multiselect', function() {
+        setup(function(done) {
+          dropdownMenu = fixture('MultiselectDropdownMenu');
+          content = Polymer.dom(dropdownMenu).querySelector('[slot="dropdown-content"]');
+          // Wait for distribution.
+          Polymer.Base.async(function() {
+            done();
+          });
+        });
+
+        test('makes multiple selections', function() {
+          expect(content.selectedValues.length).to.be.equal(2);
+        });
+
+        test('ignores select', function() {
+          expect(dropdownMenu.ignoreSelect).to.be.true;
         });
       });
     });


### PR DESCRIPTION
Add option to disable automatic closing of dropdown after selection made by exposing paper-menu-button ignoreSelect.

Fixes #53, #171