### PR TITLE
Fix 3.0 tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @valdrinkoshi
+* @bicknellr
 /.travis.yml @azakus


### PR DESCRIPTION
Travis doesn't have the right reference in the last test it tried to run for the __auto_generated_3.0_preview branch; bumping with a trivial change from master to try to get it to pick up the correct one.