### PR TITLE
Fix tests on old Safari by forcing layout via `offsetWidth`

### DIFF
--- a/test/paper-dropdown-menu-light.html
+++ b/test/paper-dropdown-menu-light.html
@@ -86,6 +86,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         expect(contentRect.height).to.be.equal(0);
 
         runAfterOpen(dropdownMenu, function() {
+          // Force layout by reading `offsetWidth`. In older versions of Safari
+          // (9, 10), calling `getBoundingClientRect` doesn't always force
+          // layout synchronously and might return an old value.
+          content.offsetWidth;
           contentRect = content.getBoundingClientRect();
 
           expect(dropdownMenu.opened).to.be.equal(true);

--- a/test/paper-dropdown-menu.html
+++ b/test/paper-dropdown-menu.html
@@ -86,6 +86,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         expect(contentRect.height).to.be.equal(0);
 
         runAfterOpen(dropdownMenu, function() {
+          // Attempt to force layout.
+          content.offsetWidth;
           contentRect = content.getBoundingClientRect();
 
           expect(dropdownMenu.opened).to.be.equal(true);

--- a/test/paper-dropdown-menu.html
+++ b/test/paper-dropdown-menu.html
@@ -86,7 +86,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         expect(contentRect.height).to.be.equal(0);
 
         runAfterOpen(dropdownMenu, function() {
-          // Attempt to force layout.
+          // Force layout by reading `offsetWidth`. In older versions of Safari
+          // (9, 10), calling `getBoundingClientRect` doesn't always force
+          // layout synchronously and might return an old value.
           content.offsetWidth;
           contentRect = content.getBoundingClientRect();
 


### PR DESCRIPTION
Attempt to force layout by reading `offsetWidth`.