### PR TITLE
Rename paper-dropdown-menu-light underline mixin; update demo.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -277,9 +277,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 font-family: serif;
                 text-transform: uppercase;
               };
-              /* no underline */
+              /* Only show the underline when focused. */
               --paper-input-container-underline: {
                 display: none;
+              };
+              --paper-input-container-underline-focus: {
+                border-color: var(--paper-cyan-500);
               };
             }
 
@@ -295,12 +298,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 font-style: normal;
                 font-family: serif;
                 text-transform: uppercase;
-                /* no underline */
+                /* Only show the underline when focused. */
                 border-bottom: none;
               };
-              /* no focus underline */
-              --paper-dropdown-menu-focus-underline: {
-                display: none;
+              --paper-dropdown-menu-underline-focus: {
+                background-color: var(--paper-cyan-500);
               };
             }
           </style>

--- a/paper-dropdown-menu-light.js
+++ b/paper-dropdown-menu-light.js
@@ -85,7 +85,7 @@ Custom property | Description | Default
 `--paper-dropdown-error-color` | The color of the label/underline when the dropdown is invalid  | `--error-color`
 `--paper-dropdown-menu-label` | Mixin applied to the label | `{}`
 `--paper-dropdown-menu-input` | Mixin applied to the input | `{}`
-`--paper-dropdown-menu-focus-underline` | Mixin applied to the focus underline | `{}`
+`--paper-dropdown-menu-underline-focus` | Mixin applied to the focus underline | `{}`
 
 Note that in this element, the underline is just the bottom border of the
 "input". To style it:
@@ -230,7 +230,7 @@ Polymer({
         visibility: hidden;
         width: 8px;
         z-index: 10;
-        @apply --paper-dropdown-menu-focus-underline;
+        @apply --paper-dropdown-menu-underline-focus;
       }
 
       :host([invalid]) label:after {


### PR DESCRIPTION
- Renames `--paper-dropdown-menu-focus-underline` -> `--paper-dropdown-menu-undeline-focus` so that the `focus` qualifier is at the end, to match paper-input-container: https://github.com/PolymerElements/paper-input/blob/ffae7ffdbd3e3ac9cf93bb6e883d8217c15d419d/paper-input-container.js#L150-L152

- Fixes the demo, which I broke in #316, so that the heavily styled example of paper-dropdown-menu-light still shows the focus underline (just not the regular one) to match the heavily styled paper-dropdown-menu.