### PR TITLE
Delegate focus to the internal button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -497,11 +497,11 @@
       }
     },
     "@polymer/polymer": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.0.5.tgz",
-      "integrity": "sha512-Zbmhtr5vZ3NoHWwFYLKI4ff7yfE6DZopI8vaS7HvmUIuNqsv/EpEDXfNEYjqePQmkMX5LU9OIKV1eX/+9aveow==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.3.1.tgz",
+      "integrity": "sha512-8KaB48tzyMjdsHdxo5KvCAaqmTe7rYDzQAoj/pyEfq9Fp4YfUaS+/xqwYj0GbiDAUNzwkmEQ7dw9cgnRNdKO8A==",
       "requires": {
-        "@webcomponents/shadycss": "^1.2.0"
+        "@webcomponents/shadycss": "^1.9.1"
       }
     },
     "@polymer/prism-element": {
@@ -688,9 +688,9 @@
       }
     },
     "@webcomponents/shadycss": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.5.0.tgz",
-      "integrity": "sha512-jNuC7alo3EfiqZPosCruJuMAaUI9qgiuGxFcFyPWjOpo4BP+vgC7hxpTzQYxbIWUgrqkn9lnfPup2hE9c/h/PQ=="
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.9.3.tgz",
+      "integrity": "sha512-fRuET+UGrH84hG0UF4iHbFqWZKUoan4/ki+iCOJ/vnKltPSHv/ZVbcA6sT/pRreznt8aKEGqN2KdHvgRxn4xjA=="
     },
     "@webcomponents/webcomponentsjs": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "@polymer/paper-menu-button": "^3.0.0-pre.26",
     "@polymer/paper-ripple": "^3.0.0-pre.26",
     "@polymer/paper-styles": "^3.0.0-pre.26",
-    "@polymer/polymer": "^3.0.0"
+    "@polymer/polymer": "^3.3.1"
   }
 }

--- a/paper-dropdown-menu-light.js
+++ b/paper-dropdown-menu-light.js
@@ -21,10 +21,17 @@ import {IronControlState} from '@polymer/iron-behaviors/iron-control-state.js';
 import {IronFormElementBehavior} from '@polymer/iron-form-element-behavior/iron-form-element-behavior.js';
 import {IronValidatableBehavior} from '@polymer/iron-validatable-behavior/iron-validatable-behavior.js';
 import {PaperRippleBehavior} from '@polymer/paper-behaviors/paper-ripple-behavior.js';
+import {LegacyElementMixin} from '@polymer/polymer/lib/legacy/legacy-element-mixin.js';
 import {Polymer} from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import {dom} from '@polymer/polymer/lib/legacy/polymer.dom.js';
 import * as gestures from '@polymer/polymer/lib/utils/gestures.js';
 import {html} from '@polymer/polymer/lib/utils/html-tag.js';
+import {wrap} from '@polymer/polymer/lib/utils/wrap.js';
+
+// LegacyElementMixin dedupes and this is the base class for elements created
+// with the `Polymer` function, so this is only a cache lookup.
+// https://github.com/Polymer/polymer/blob/640bc80ac7177b761d46b2fa9c455c318f2b85c6/lib/legacy/class.js#L533-L534
+const LegacyPolymerElementBase = LegacyElementMixin(HTMLElement);
 
 /**
 Material design: [Dropdown
@@ -104,10 +111,6 @@ Polymer({
   /** @override */
   _template: html`
     <style include="paper-dropdown-menu-shared-styles">
-      :host(:focus) {
-        outline: none;
-      }
-
       :host {
         width: 200px;  /* Default size of an <input> */
       }
@@ -408,6 +411,24 @@ Polymer({
   keyBindings: {'up down': 'open', 'esc': 'close'},
 
   observers: ['_selectedItemChanged(selectedItem)'],
+
+  /**
+   * Override `_attachDom` so that we can pass `delegatesFocus`. The overridden
+   * implementation of `_attachDom` specifically skips the steps performed here
+   * if the node already hosts a shadow root:
+   * https://github.com/Polymer/polymer/blob/640bc80ac7177b761d46b2fa9c455c318f2b85c6/lib/mixins/element-mixin.js#L691-L694
+   * @override
+   */
+  _attachDom(dom) {
+    const wrappedThis = wrap(this);
+    wrappedThis.attachShadow({
+      mode: 'open',
+      delegatesFocus: true,
+      shadyUpgradeFragment: dom,
+    });
+    wrappedThis.shadowRoot.appendChild(dom);
+    return LegacyPolymerElementBase.prototype._attachDom.call(this, dom);
+  },
 
   /** @override */
   attached: function() {

--- a/paper-dropdown-menu-light.js
+++ b/paper-dropdown-menu-light.js
@@ -290,7 +290,7 @@ Polymer({
 
     <paper-menu-button id="menuButton" vertical-align="[[verticalAlign]]" horizontal-align="[[horizontalAlign]]" vertical-offset="[[_computeMenuVerticalOffset(noLabelFloat, verticalOffset)]]" disabled="[[disabled]]" no-animations="[[noAnimations]]" on-iron-select="_onIronSelect" on-iron-deselect="_onIronDeselect" opened="{{opened}}" close-on-activate allow-outside-scroll="[[allowOutsideScroll]]">
       <!-- support hybrid mode: user might be using paper-menu-button 1.x which distributes via <content> -->
-      <div class="dropdown-trigger" slot="dropdown-trigger" role="button" tabindex="0" aria-haspopup="listbox">
+      <div id="dropdown-trigger" class="dropdown-trigger" slot="dropdown-trigger" role="button" tabindex="0" aria-haspopup="listbox">
         <label class$="[[_computeLabelClass(noLabelFloat,alwaysFloatLabel,hasContent)]]">
           [[label]]
         </label>
@@ -428,6 +428,16 @@ Polymer({
     });
     wrappedThis.shadowRoot.appendChild(dom);
     return LegacyPolymerElementBase.prototype._attachDom.call(this, dom);
+  },
+
+  focus() {
+    // When using Shady DOM and in browsers that don't support
+    // `delegatesFocus`, attempting to focus this element with the browser's
+    // native `HTMLElement#focus` will cause focus to be lost because this
+    // element isn't focusable in those situations. To work around this, the
+    // element in the shadow root that this element intends to delegate focus
+    // to is manually focused instead.
+    this.$['dropdown-trigger'].focus();
   },
 
   /** @override */

--- a/paper-dropdown-menu-shared-styles.js
+++ b/paper-dropdown-menu-shared-styles.js
@@ -39,6 +39,12 @@ $_documentContainer.innerHTML =
         @apply --paper-dropdown-menu;
       }
 
+      /* paper-dropdown-menu and paper-dropdown-menu-light both delegate focus
+       * to other internal elements which manage focus styling. */
+      :host(:focus) {
+        outline: none;
+      }
+
       :host(:dir(rtl)) {
         text-align: right;
 

--- a/paper-dropdown-menu.js
+++ b/paper-dropdown-menu.js
@@ -100,7 +100,7 @@ Polymer({
       <div class="dropdown-trigger" slot="dropdown-trigger">
         <paper-ripple></paper-ripple>
         <!-- paper-input has type="text" for a11y, do not remove -->
-        <paper-input type="text" invalid="[[invalid]]" readonly disabled="[[disabled]]" value="[[value]]" placeholder="[[placeholder]]" error-message="[[errorMessage]]" always-float-label="[[alwaysFloatLabel]]" no-label-float="[[noLabelFloat]]" label="[[label]]" input-role="button" input-aria-haspopup="listbox" autocomplete="off">
+        <paper-input id="input" type="text" invalid="[[invalid]]" readonly disabled="[[disabled]]" value="[[value]]" placeholder="[[placeholder]]" error-message="[[errorMessage]]" always-float-label="[[alwaysFloatLabel]]" no-label-float="[[noLabelFloat]]" label="[[label]]" input-role="button" input-aria-haspopup="listbox" autocomplete="off">
           <!-- support hybrid mode: user might be using paper-input 1.x which distributes via <content> -->
           <iron-icon icon="paper-dropdown-menu:arrow-drop-down" suffix slot="suffix"></iron-icon>
         </paper-input>
@@ -249,6 +249,16 @@ Polymer({
     });
     wrappedThis.shadowRoot.appendChild(dom);
     return LegacyPolymerElementBase.prototype._attachDom.call(this, dom);
+  },
+
+  focus() {
+    // When using Shady DOM and in browsers that don't support
+    // `delegatesFocus`, attempting to focus this element with the browser's
+    // native `HTMLElement#focus` will cause focus to be lost because this
+    // element isn't focusable in those situations. To work around this, the
+    // element in the shadow root that this element intends to delegate focus
+    // to is manually focused instead.
+    this.$.input._focusableElement.focus();
   },
 
   /** @override */

--- a/paper-dropdown-menu.js
+++ b/paper-dropdown-menu.js
@@ -22,10 +22,17 @@ import {IronButtonState} from '@polymer/iron-behaviors/iron-button-state.js';
 import {IronControlState} from '@polymer/iron-behaviors/iron-control-state.js';
 import {IronFormElementBehavior} from '@polymer/iron-form-element-behavior/iron-form-element-behavior.js';
 import {IronValidatableBehavior} from '@polymer/iron-validatable-behavior/iron-validatable-behavior.js';
+import {LegacyElementMixin} from '@polymer/polymer/lib/legacy/legacy-element-mixin.js';
 import {Polymer} from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import {dom} from '@polymer/polymer/lib/legacy/polymer.dom.js';
 import * as gestures from '@polymer/polymer/lib/utils/gestures.js';
 import {html} from '@polymer/polymer/lib/utils/html-tag.js';
+import {wrap} from '@polymer/polymer/lib/utils/wrap.js';
+
+// LegacyElementMixin dedupes and this is the base class for elements created
+// with the `Polymer` function, so this is only a cache lookup.
+// https://github.com/Polymer/polymer/blob/640bc80ac7177b761d46b2fa9c455c318f2b85c6/lib/legacy/class.js#L533-L534
+const LegacyPolymerElementBase = LegacyElementMixin(HTMLElement);
 
 /**
 Material design: [Dropdown
@@ -225,6 +232,24 @@ Polymer({
   keyBindings: {'up down': 'open', 'esc': 'close'},
 
   observers: ['_selectedItemChanged(selectedItem)'],
+
+  /**
+   * Override `_attachDom` so that we can pass `delegatesFocus`. The overridden
+   * implementation of `_attachDom` specifically skips the steps performed here
+   * if the node already hosts a shadow root:
+   * https://github.com/Polymer/polymer/blob/640bc80ac7177b761d46b2fa9c455c318f2b85c6/lib/mixins/element-mixin.js#L691-L694
+   * @override
+   */
+  _attachDom(dom) {
+    const wrappedThis = wrap(this);
+    wrappedThis.attachShadow({
+      mode: 'open',
+      delegatesFocus: true,
+      shadyUpgradeFragment: dom,
+    });
+    wrappedThis.shadowRoot.appendChild(dom);
+    return LegacyPolymerElementBase.prototype._attachDom.call(this, dom);
+  },
 
   /** @override */
   attached: function() {


### PR DESCRIPTION
This PR overrides `_attachDom` so that `delegatesFocus` can be set when attaching the shadow root. This is going into #317 instead of master.